### PR TITLE
Allow redirect callback host to be configurable

### DIFF
--- a/Development/OpenPassDevelopmentApp/Info.plist
+++ b/Development/OpenPassDevelopmentApp/Info.plist
@@ -17,5 +17,7 @@
 	<string>http://localhost:8888</string>
 	<key>OpenPassClientId</key>
 	<string>b3044f3612f7cfdf237331d9d38d2477</string>
+	<key>OpenPassRedirectHost</key>
+	<string>com.myopenpass.devapp</string>
 </dict>
 </plist>

--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -54,11 +54,15 @@ public final class OpenPassManager: NSObject {
     /// OpenPass Client Redirect Uri
     private var redirectUri: String? {
         guard let redirectScheme = redirectScheme else { return nil }
-        return redirectScheme + "://com.myopenpass.devapp"
+        guard let redirectHost = redirectHost else { return nil }
+        return redirectScheme + "://" + redirectHost
     }
     
     /// Client specific redirect scheme
     private var redirectScheme: String?
+    
+    /// Client specific redirect host
+    private var redirectHost: String?
     
     /// The SDK name. This is being send to the API via HTTP headers to track metrics.
     private let sdkName = "openpass-ios-sdk"
@@ -93,6 +97,11 @@ public final class OpenPassManager: NSObject {
                 break
             }
         }
+        
+        guard let redirectHost = Bundle.main.object(forInfoDictionaryKey: "OpenPassRedirectHost") as? String, !redirectHost.isEmpty else {
+            return
+        }
+        self.redirectHost = redirectHost
         
         self.openPassClient = OpenPassClient(baseURL: baseURL ?? defaultBaseURL, baseRequestParameters: baseRequestParameters)
         


### PR DESCRIPTION
Currently the redirect host is hardcoded as `com.myopenpass.devapp` which obviously isn't very useful. This PR adds a new property list key `OpenPassRedirectHost`, which allows apps to provide their own host.