### PR TITLE
Remove V From Version Number Instructions

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -5,11 +5,11 @@ Releases are performed via [GitHub Releases](https://docs.github.com/en/reposito
 ### Steps
 
 1. Confirm `sdkVersion` in `OpenPassManager` is expected version.
-2. Use GitHub Releases to create tag matching "v`sdkVersion`" in `OpenPassManager` and publish release.
+2. Use GitHub Releases to create tag matching `sdkVersion` in `OpenPassManager` and publish release.
 3. Update `sdkVersion` in `OpenPassManger` to next minor version to support future development and merge into `main`.
 
 ### Version Numbers
 
-Version Numbering follows [Semantic Versioning](https://semver.org) standards.  The format is `vMAJOR.MINOR.PATCH`.. ex `v0.1.0`
+Version Numbering follows [Semantic Versioning](https://semver.org) standards.  The format is `MAJOR.MINOR.PATCH`.. ex `0.1.0`
 
 <img width="753" alt="semver-summary" src="https://user-images.githubusercontent.com/989928/230925438-ac6ac422-6358-4e96-9536-e3f8fc935317.png">


### PR DESCRIPTION
Changes Tag version template to only include **3 period separated values** as [specified by Swift Package Manager documentation](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#version). 
