### PR TITLE
Fix URL scheme Bundle extraction

### DIFF
--- a/Sources/OpenPass/Extensions/OpenPassManager+Extensions.swift
+++ b/Sources/OpenPass/Extensions/OpenPassManager+Extensions.swift
@@ -60,3 +60,13 @@ extension OpenPassManager {
     }
 
 }
+
+/// Returns the first URL scheme suitable for an OpenPass `redirect_uri`.
+/// - Parameter urlTypes: A Bundle's `CFBundleURLTypes` dictionary
+/// - Returns: URL scheme
+internal func openPassRedirectScheme(urlTypes: [[String: Any]]) -> String? {
+    urlTypes
+        .compactMap { $0["CFBundleURLSchemes"] as? [String] }
+        .flatMap { $0 }
+        .first { $0.hasPrefix("com.myopenpass.auth.") }
+}

--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -88,15 +88,8 @@ public final class OpenPassManager: NSObject {
         } else {
             self.baseURL = defaultBaseURL
         }
-        
-        if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]] {
-            for urlTypeDictionary in urlTypes {
-                guard let urlSchemes = urlTypeDictionary["CFBundleURLSchemes"] as? [String] else { continue }
-                guard let externalURLScheme = urlSchemes.first else { continue }
-                self.redirectScheme = externalURLScheme
-                break
-            }
-        }
+
+        self.redirectScheme = (Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]]).flatMap(openPassRedirectScheme(urlTypes:))
         
         guard let redirectHost = Bundle.main.object(forInfoDictionaryKey: "OpenPassRedirectHost") as? String, !redirectHost.isEmpty else {
             return

--- a/Tests/OpenPassTests/OpenPassManagerTests.swift
+++ b/Tests/OpenPassTests/OpenPassManagerTests.swift
@@ -45,4 +45,17 @@ final class OpenPassManagerTests: XCTestCase {
         XCTAssertEqual(generatedCodeChallenge, codeChallenge, "Generated Code Challenge not generated correctly")
     }
     
+    func testURLSchemeExtraction() {
+        let urlTypes = [
+            ["CFBundleURLSchemes": ["test"]],
+            ["CFBundleURLSchemes": ["com.myopenpass.auth.1234"]],
+        ]
+        XCTAssertEqual("com.myopenpass.auth.1234", openPassRedirectScheme(urlTypes: urlTypes))
+
+        let invalidUrlTypes = [
+            ["CFBundleURLSchemes": ["com.myopenpass.invalid.1234"]],
+            ["CFBundleURLSchemes": ["com.myopenpass.auth1234"]]
+        ]
+        XCTAssertNil(openPassRedirectScheme(urlTypes: invalidUrlTypes))
+    }
 }


### PR DESCRIPTION
A valid OpenPass `redirect_uri` scheme must have the prefix `com.myopenpass.auth.`. Prior to this change, the SDK is looking for the first registered URL Type scheme, which may not always be correct.

## Test plan

New unit tests in `Tests/OpenPassTests/OpenPassManagerTests.swift`
