### PR TITLE
Build redirect_uri scheme from Client ID

### DIFF
--- a/Development/OpenPassDevelopmentApp/Info.plist
+++ b/Development/OpenPassDevelopmentApp/Info.plist
@@ -2,17 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string></string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>com.myopenpass.auth.421d407048794885b2baf4dbcde185cb</string>
-			</array>
-		</dict>
-	</array>
 	<key>OpenPassClientId</key>
 	<string>421d407048794885b2baf4dbcde185cb</string>
 	<key>OpenPassRedirectHost</key>

--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -58,9 +58,14 @@ public final class OpenPassManager: NSObject {
         return redirectScheme + "://" + redirectHost
     }
     
-    /// Client specific redirect scheme
-    private var redirectScheme: String?
-    
+    /// Client specific redirect scheme. This always of the form `com.myopenpass.auth.{CLIENT_ID}`.
+    private var redirectScheme: String? {
+        guard let clientId else {
+            return nil
+        }
+        return "com.myopenpass.auth.\(clientId)"
+    }
+
     /// Client specific redirect host
     private var redirectHost: String?
     
@@ -87,15 +92,6 @@ public final class OpenPassManager: NSObject {
             self.baseURL = baseURLOverride
         } else {
             self.baseURL = defaultBaseURL
-        }
-        
-        if let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]] {
-            for urlTypeDictionary in urlTypes {
-                guard let urlSchemes = urlTypeDictionary["CFBundleURLSchemes"] as? [String] else { continue }
-                guard let externalURLScheme = urlSchemes.first else { continue }
-                self.redirectScheme = externalURLScheme
-                break
-            }
         }
         
         guard let redirectHost = Bundle.main.object(forInfoDictionaryKey: "OpenPassRedirectHost") as? String, !redirectHost.isEmpty else {


### PR DESCRIPTION
Per @cjbhaines, the auth `redirect_uri` scheme is always in the form `com.myopenpass.auth.{CLIENT_ID}` therefore we don't need anyone integrating this SDK to provide it.

Additionally, `ASWebAuthenticationSession` does not require the registration of the scheme, so it is not appropriate or required to specify it in `CFBundleURLTypes`.

This change removes the custom scheme entry in `CFBundleURLTypes` and builds the redirect scheme from the client ID.

This PR also updates the Development App's Info.plist with a new (sample app) client ID and removes the custom server base URL as production should be used.

## Test plan

Run the Development App and complete the sign in UX.
