### PR TITLE
Add tests for Sign-in flow

### DIFF
--- a/Sources/OpenPass/Extensions/OpenPassManager+Extensions.swift
+++ b/Sources/OpenPass/Extensions/OpenPassManager+Extensions.swift
@@ -28,18 +28,6 @@ import AuthenticationServices
 import CryptoKit
 import Foundation
 
-#if os(iOS)
-@available(iOS 13.0, *)
-extension OpenPassManager: ASWebAuthenticationPresentationContextProviding {
-    /// Apple provided API for telling the delegate from which window it should present content to the user.
-    /// - Parameter session: Current session being used to perform authentication
-    /// - Returns: `ASPresentationAnchor` for the system to use to display the `ASWebAuthenticationSession`
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return ASPresentationAnchor()
-    }
-}
-#endif
-
 @available(iOS 13.0, tvOS 16.0, *)
 extension OpenPassManager {
     

--- a/Tests/OpenPassTests/OpenPassManagerTests.swift
+++ b/Tests/OpenPassTests/OpenPassManagerTests.swift
@@ -13,7 +13,7 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-//The above copyright notice and this permission notice shall be included in all
+// The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -27,22 +27,230 @@
 
 @testable import OpenPass
 import XCTest
+import AuthenticationServices
 
 @available(iOS 13.0, *)
+@MainActor
 final class OpenPassManagerTests: XCTestCase {
 
-    // Base64-URL Encoded String
-    let codeVerifier = "2hrVVNjQL-5JuQTCqrdIgHTVIIFQnxEXGOTy1VNkuQM"
+    static let defaultAuthenticationCallbackURL = URL(string: "com.myopenpass.auth.test-client://com.openpass?state=state123&code=123456")!
 
-    // SHA256 digested and then Base64-URL Encoded String
-    let codeChallenge = "rrw_o86gcCbS5BGxT-FUC-AoVjDyMXpRDiYjXUR0Kak"
-    
-    @MainActor
+    /// Test helper. Runs the sign in flow with default, 'success' parameters. Override parameters to test failure scenarios.
+    private func _testSignInUXFlow(
+        callbackURL: URL = OpenPassManagerTests.defaultAuthenticationCallbackURL,
+        authenticationState: String = "state123",
+        authenticationSession: AuthenticationSession? = nil,
+        overrideFixtures: [String:(String, Int)] = [:],
+        tokenValidator: IDTokenValidation = IDTokenValidationStub.valid
+    ) async throws -> OpenPassTokens {
+        let defaultFixtures = [
+            "/v1/api/token": ("openpasstokens-200", 200),
+            "/.well-known/jwks": ("jwks", 200),
+        ]
+        // overrides in fixtures replace defaults
+        let fixtures = defaultFixtures.merging(overrideFixtures) { $1 }
+        try HTTPStub.shared.stub(fixtures: fixtures)
+
+        let manager = OpenPassManager(
+            clientId: "test-client",
+            redirectHost: "com.openpass",
+            authenticationSession: authenticationSession ?? { _, _ in callbackURL },
+            authenticationStateGenerator: .init { authenticationState },
+            tokenValidator: tokenValidator
+        )
+
+        return try await manager.beginSignInUXFlow()
+    }
+
+    // MARK: - Sign In Flow
+
+    func testSignInSuccess() async throws {
+        let tokens = try await _testSignInUXFlow()
+        XCTAssertNotNil(tokens, "Expected sign-in to succeed and return tokens")
+    }
+
+    func testSignInUserCancelled() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                authenticationSession: { url, callbackURLScheme in
+                    throw ASWebAuthenticationSessionError(_nsError: NSError(
+                        domain: ASWebAuthenticationSessionError.errorDomain,
+                        code: ASWebAuthenticationSessionError.canceledLogin.rawValue
+                    ))
+                }
+            )
+        ) { error in
+            XCTAssertEqual(error, .authorizationCancelled)
+        }
+    }
+
+    func testSignInAuthStateMismatch() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                authenticationState: "bad state"
+            )
+        ) { error in
+            XCTAssertEqual(error, .authorizationCallBackDataItems)
+        }
+    }
+
+    func testSignInAuthError() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                authenticationSession: { _, _ in
+                    URL(string: "com.myopenpass.auth.test-client://com.openpass?error=invalid&error_description=auth-was-bad")!
+                }
+            )
+        ) { error in
+            XCTAssertEqual(error, .authorizationError(code: "invalid", description: "auth-was-bad"))
+        }
+    }
+
+    func testSignInInternalServerError() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                overrideFixtures: [
+                    "/v1/api/token": ("openpasstokens-500", 500),
+                ]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error,
+                .tokenData(
+                    name: "server_error",
+                    description: "An unexpected error has occurred",
+                    uri: "https://auth.myopenpass.com"
+                )
+            )
+        }
+    }
+
+    func testSignInBadTokenResponse() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                overrideFixtures: [
+                    "/v1/api/token": ("token-bad-data", 200),
+                ]
+            )
+        ) { error in
+            XCTAssertEqual(error, .verificationFailedForOIDCToken)
+        }
+    }
+
+    func testSignInInvalidToken() async throws {
+        try await assertThrowsOpenPassError(
+            await self._testSignInUXFlow(
+                tokenValidator: IDTokenValidationStub.invalid
+            )
+        ) { error in
+            XCTAssertEqual(error, .verificationFailedForOIDCToken)
+        }
+    }
+
+    // MARK: -
+
+    func testAuthenticationSessionURL() async throws {
+        let _ = try await _testSignInUXFlow { url, callbackURLScheme in
+            XCTAssertEqual(callbackURLScheme, "com.myopenpass.auth.test-client")
+
+            let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            XCTAssertEqual(components.scheme, "https")
+            XCTAssertEqual(components.host, "auth.myopenpass.com")
+            XCTAssertEqual(components.path, "/v1/api/authorize")
+
+            // Don't test random/platform-specific values
+            let ignoredQueryItems: Set = ["code_challenge", "device_model", "device_platform_version"]
+            let queryItems = (components.queryItems ?? [])
+                .filter { !ignoredQueryItems.contains($0.name) }
+                .sorted { $0.name < $1.name }
+            XCTAssertEqual(queryItems, [
+                .init(name: "client_id", value: "test-client"),
+                .init(name: "code_challenge_method", value: "S256"),
+                .init(name: "device_manufacturer", value: "Apple"),
+                .init(name: "device_platform", value: "iOS"),
+                .init(name: "redirect_uri", value: "com.myopenpass.auth.test-client://com.openpass"),
+                .init(name: "response_type", value: "code"),
+                .init(name: "scope", value: "openid"),
+                .init(name: "sdk_name", value: "openpass-ios-sdk"),
+                .init(name: "sdk_version", value: "1.1.0"),
+                .init(name: "state", value: "state123"),
+            ])
+
+            return Self.defaultAuthenticationCallbackURL
+        }
+    }
+
     func testGenerateCodeChallengeFromVerifierCode() {
-        
-        let generatedCodeChallenge = OpenPassManager.shared.generateCodeChallengeFromVerifierCode(verifier: codeVerifier)
-        
+        // Base64-URL Encoded String
+        let codeVerifier = "2hrVVNjQL-5JuQTCqrdIgHTVIIFQnxEXGOTy1VNkuQM"
+
+        // SHA256 digested and then Base64-URL Encoded String
+        let codeChallenge = "rrw_o86gcCbS5BGxT-FUC-AoVjDyMXpRDiYjXUR0Kak"
+
+        let manager = OpenPassManager(clientId: "123", redirectHost: "openpass")
+        let generatedCodeChallenge = manager.generateCodeChallengeFromVerifierCode(verifier: codeVerifier)
+
         XCTAssertEqual(generatedCodeChallenge, codeChallenge, "Generated Code Challenge not generated correctly")
     }
-    
+}
+
+// MARK: - Test Utils
+
+struct IDTokenValidationStub: IDTokenValidation {
+    var valid: Bool
+
+    func validate(_ token: IDToken, jwks: JWKS) throws -> Bool {
+        valid
+    }
+
+    static let valid = Self(valid: true)
+    static let invalid = Self(valid: false)
+}
+
+internal func assertThrowsOpenPassError<T>(
+    _ expression: @escaping @autoclosure () async throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ errorHandler: (_ error: OpenPassError) -> Void = { _ in }
+) async {
+    // Use `Result.get` to rethrow inside `XCTAssertThrowsError` after the asynchronous `expression` is complete.
+    let result = await Task {
+        try await expression()
+    }.result
+    XCTAssertThrowsError(try result.get(), message(), file: file, line: line, { untypedError in
+        guard let error = untypedError as? OpenPassError else {
+            XCTFail("Expected error of type \(OpenPassError.self)")
+            return
+        }
+        errorHandler(error)
+    })
+}
+
+/// Convenience for tests only.
+extension OpenPassError: Equatable {
+    public static func == (lhs: OpenPassError, rhs: OpenPassError) -> Bool {
+        switch (lhs, rhs) {
+        case (.missingConfiguration, .missingConfiguration):
+            return true
+        case (.authorizationUrl, .authorizationUrl):
+            return true
+        case (.authorizationCancelled, .authorizationCancelled):
+            return true
+        case (.authorizationCallBackDataItems, .authorizationCallBackDataItems):
+            return true
+        case (.tokenData(let lName, let lDescription, let lUri), .tokenData(let rName, let rDescription, let rUri)):
+            return lName == rName && lDescription == rDescription && lUri == rUri
+        case (.verificationFailedForOIDCToken, .verificationFailedForOIDCToken):
+            return true
+        case (.invalidJWKS, .invalidJWKS):
+            return true
+        case (.authorizationError(let lCode, let lDescription), .authorizationError(let rCode, let rDescription)):
+            return lCode == rCode && lDescription == rDescription
+        case (.urlGeneration, .urlGeneration):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Tests/OpenPassTests/TestData/token-bad-data.json
+++ b/Tests/OpenPassTests/TestData/token-bad-data.json
@@ -1,0 +1,6 @@
+{
+  "id_token": "not a real token",
+  "access_token": "not a real token",
+  "token_type": "Bearer",
+  "expires_in": 86400
+}


### PR DESCRIPTION
Further `OpenPassManager` cleanup:
* Add an internal init for providing dependencies for testing
* Factor out authentication so that we can test without actually invoking `ASWebAuthenticationSession`
* Add tests for `OpenPassManager.beginSignInUXFlow()` to allow us to make further changes with confidence
* Broke up `OpenPassManager.beginSignInUXFlow` into shorter functions, reduced nesting