### PR TITLE
Increase code_verifier length to meet spec

### DIFF
--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -172,7 +172,7 @@ public final class OpenPassManager {
 
         // Build authentication request URL
         let authorizeState = authenticationStateGenerator()
-        let codeVerifier = randomString(length: 32)
+        let codeVerifier = randomString(length: 43)
         let challengeHashString = generateCodeChallengeFromVerifierCode(verifier: codeVerifier)
 
         var components = URLComponents(string: baseURL)


### PR DESCRIPTION
This PR increases the length of `code_verifier` to be 43 characters, as defined as the minimum in: https://datatracker.ietf.org/doc/html/rfc7636#section-4.1