### PR TITLE
Add Device UI Tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/build
 /Packages
 *.xcworkspace
 xcuserdata/
@@ -9,3 +10,6 @@ DerivedData/
 .netrc
 **/Package.resolved
 /Development/docs
+
+# Ignore the populated configuration file to avoid exposing secrets
+Development/OpenPassDevelopmentAppUITests/configuration.json

--- a/Development/OpenPassDevelopmentApp.xcodeproj/project.pbxproj
+++ b/Development/OpenPassDevelopmentApp.xcodeproj/project.pbxproj
@@ -3,10 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF22CC1F2CE3AC89003C0163 /* mailslurp in Frameworks */ = {isa = PBXBuildFile; productRef = BF22CC1E2CE3AC89003C0163 /* mailslurp */; };
+		BF22CC222CE41074003C0163 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = BF22CC212CE41074003C0163 /* SwiftSoup */; };
 		BFEB6D9D2BB2F1E600A1CD75 /* DeviceAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEB6D9C2BB2F1E600A1CD75 /* DeviceAuthorizationViewModel.swift */; };
 		E245BA5F293F9C150053DCB2 /* OpenPassTokensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E245BA5E293F9C150053DCB2 /* OpenPassTokensView.swift */; };
 		E262B3DD2913FD1100C55A06 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E262B3DC2913FD1100C55A06 /* Localizable.strings */; };
@@ -19,7 +21,18 @@
 		E2E9795A28F9E5AE00E46CE8 /* OpenPass in Frameworks */ = {isa = PBXBuildFile; productRef = E2E9795928F9E5AE00E46CE8 /* OpenPass */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		BF4F1F712CE2677000D35A5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E298110528F9DDC400A6A6E0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E298110C28F9DDC400A6A6E0;
+			remoteInfo = OpenPassDevelopmentApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		BF4F1F6B2CE2677000D35A5D /* OpenPassDevelopmentAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenPassDevelopmentAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFEB6D9C2BB2F1E600A1CD75 /* DeviceAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAuthorizationViewModel.swift; sourceTree = "<group>"; };
 		E245BA5E293F9C150053DCB2 /* OpenPassTokensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPassTokensView.swift; sourceTree = "<group>"; };
 		E262B3DC2913FD1100C55A06 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
@@ -35,7 +48,30 @@
 		E2E9795728F9E58900E46CE8 /* openpass-ios-sdk */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "openpass-ios-sdk"; path = ..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		BF22CC452CE6AAFE003C0163 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				configuration.json.tpl,
+			);
+			target = BF4F1F6A2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		BF4F1F6C2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (BF22CC452CE6AAFE003C0163 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = OpenPassDevelopmentAppUITests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		BF4F1F682CE2677000D35A5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF22CC1F2CE3AC89003C0163 /* mailslurp in Frameworks */,
+				BF22CC222CE41074003C0163 /* SwiftSoup in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E298110A28F9DDC400A6A6E0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -52,6 +88,7 @@
 			children = (
 				E2E9795628F9E58900E46CE8 /* Packages */,
 				E298110F28F9DDC400A6A6E0 /* OpenPassDevelopmentApp */,
+				BF4F1F6C2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */,
 				E298110E28F9DDC400A6A6E0 /* Products */,
 				E2E9795828F9E5AE00E46CE8 /* Frameworks */,
 			);
@@ -61,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				E298110D28F9DDC400A6A6E0 /* OpenPassDevelopmentApp.app */,
+				BF4F1F6B2CE2677000D35A5D /* OpenPassDevelopmentAppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -101,6 +139,31 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		BF4F1F6A2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF4F1F752CE2677000D35A5D /* Build configuration list for PBXNativeTarget "OpenPassDevelopmentAppUITests" */;
+			buildPhases = (
+				BF4F1F672CE2677000D35A5D /* Sources */,
+				BF4F1F682CE2677000D35A5D /* Frameworks */,
+				BF4F1F692CE2677000D35A5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BF4F1F722CE2677000D35A5D /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				BF4F1F6C2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */,
+			);
+			name = OpenPassDevelopmentAppUITests;
+			packageProductDependencies = (
+				BF22CC1E2CE3AC89003C0163 /* mailslurp */,
+				BF22CC212CE41074003C0163 /* SwiftSoup */,
+			);
+			productName = OpenPassDevelopmentAppUITests;
+			productReference = BF4F1F6B2CE2677000D35A5D /* OpenPassDevelopmentAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		E298110C28F9DDC400A6A6E0 /* OpenPassDevelopmentApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E298112128F9DDC500A6A6E0 /* Build configuration list for PBXNativeTarget "OpenPassDevelopmentApp" */;
@@ -129,9 +192,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1400;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					BF4F1F6A2CE2677000D35A5D = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = E298110C28F9DDC400A6A6E0;
+					};
 					E298110C28F9DDC400A6A6E0 = {
 						CreatedOnToolsVersion = 14.0;
 					};
@@ -146,16 +213,28 @@
 				Base,
 			);
 			mainGroup = E298110428F9DDC400A6A6E0;
+			packageReferences = (
+				BF22CC1D2CE3AC89003C0163 /* XCRemoteSwiftPackageReference "mailslurp-client-swift" */,
+				BF22CC202CE41074003C0163 /* XCRemoteSwiftPackageReference "SwiftSoup" */,
+			);
 			productRefGroup = E298110E28F9DDC400A6A6E0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				E298110C28F9DDC400A6A6E0 /* OpenPassDevelopmentApp */,
+				BF4F1F6A2CE2677000D35A5D /* OpenPassDevelopmentAppUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		BF4F1F692CE2677000D35A5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E298110B28F9DDC400A6A6E0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -189,6 +268,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		BF4F1F672CE2677000D35A5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E298110928F9DDC400A6A6E0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -205,6 +291,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		BF4F1F722CE2677000D35A5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E298110C28F9DDC400A6A6E0 /* OpenPassDevelopmentApp */;
+			targetProxy = BF4F1F712CE2677000D35A5D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		E298111B28F9DDC500A6A6E0 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -217,6 +311,51 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		BF4F1F732CE2677000D35A5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UW77J35X4D;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openpass.OpenPassDevelopmentAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = OpenPassDevelopmentApp;
+			};
+			name = Debug;
+		};
+		BF4F1F742CE2677000D35A5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UW77J35X4D;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openpass.OpenPassDevelopmentAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = OpenPassDevelopmentApp;
+			};
+			name = Release;
+		};
 		E298111F28F9DDC500A6A6E0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -402,6 +541,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		BF4F1F752CE2677000D35A5D /* Build configuration list for PBXNativeTarget "OpenPassDevelopmentAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF4F1F732CE2677000D35A5D /* Debug */,
+				BF4F1F742CE2677000D35A5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E298110828F9DDC400A6A6E0 /* Build configuration list for PBXProject "OpenPassDevelopmentApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -422,7 +570,36 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		BF22CC1D2CE3AC89003C0163 /* XCRemoteSwiftPackageReference "mailslurp-client-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mailslurp/mailslurp-client-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.19.22;
+			};
+		};
+		BF22CC202CE41074003C0163 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/scinfu/SwiftSoup.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.6;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		BF22CC1E2CE3AC89003C0163 /* mailslurp */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF22CC1D2CE3AC89003C0163 /* XCRemoteSwiftPackageReference "mailslurp-client-swift" */;
+			productName = mailslurp;
+		};
+		BF22CC212CE41074003C0163 /* SwiftSoup */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF22CC202CE41074003C0163 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
+			productName = SwiftSoup;
+		};
 		E2E9795928F9E5AE00E46CE8 /* OpenPass */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = OpenPass;

--- a/Development/OpenPassDevelopmentApp.xcodeproj/xcshareddata/xcschemes/OpenPassDevelopmentApp.xcscheme
+++ b/Development/OpenPassDevelopmentApp.xcodeproj/xcshareddata/xcschemes/OpenPassDevelopmentApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1410"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:OpenPassDevelopmentApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF4F1F6A2CE2677000D35A5D"
+               BuildableName = "OpenPassDevelopmentAppUITests.xctest"
+               BlueprintName = "OpenPassDevelopmentAppUITests"
+               ReferencedContainer = "container:OpenPassDevelopmentApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -27,7 +41,26 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-Mobile.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-DeviceAuth.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF4F1F6A2CE2677000D35A5D"
+               BuildableName = "OpenPassDevelopmentAppUITests.xctest"
+               BlueprintName = "OpenPassDevelopmentAppUITests"
+               ReferencedContainer = "container:OpenPassDevelopmentApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Development/OpenPassDevelopmentApp/DeviceAuthorizationView.swift
+++ b/Development/OpenPassDevelopmentApp/DeviceAuthorizationView.swift
@@ -24,7 +24,6 @@
 // SOFTWARE.
 //
 
-#if os(tvOS)
 import OpenPass
 import SwiftUI
 
@@ -47,7 +46,11 @@ struct DeviceAuthorizationView: View {
             case .deviceCodeAvailable(let deviceCode):
                 LabelItem("daf.label.usercode", value: deviceCode.userCode)
                 LabelItem("daf.label.verificationuri", value: deviceCode.verificationUri)
-                LabelItem("daf.label.verficationuricomplete", value: deviceCode.verificationUriComplete ?? "")
+                LabelItem(
+                    "daf.label.verficationuricomplete",
+                    value: deviceCode.verificationUriComplete ?? "",
+                    accessibilityIdentifier: "verificationUriComplete"
+                )
 
                 if let verificationUriCompleteImage = viewModel.verificationUriCompleteImage {
                     Image(uiImage: verificationUriCompleteImage)
@@ -90,10 +93,12 @@ struct DeviceAuthorizationView: View {
 private struct LabelItem: View {
     var label: LocalizedStringKey
     var value: String
+    var accessibilityIdentifier: String
 
-    init(_ label: LocalizedStringKey, value: String) {
+    init(_ label: LocalizedStringKey, value: String, accessibilityIdentifier: String = "") {
         self.label = label
         self.value = value
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 
     var body: some View {
@@ -102,6 +107,6 @@ private struct LabelItem: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         Text(value)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifierIfAvailable(accessibilityIdentifier)
     }
 }
-#endif

--- a/Development/OpenPassDevelopmentApp/DeviceAuthorizationViewModel.swift
+++ b/Development/OpenPassDevelopmentApp/DeviceAuthorizationViewModel.swift
@@ -24,8 +24,6 @@
 // SOFTWARE.
 //
 
-#if os(tvOS)
-
 import CoreImage.CIFilterBuiltins
 import Foundation
 import OpenPass
@@ -117,4 +115,3 @@ extension UIImage {
             .flatMap(UIImage.init(data: ))
     }
 }
-#endif

--- a/Development/OpenPassDevelopmentApp/Localizable.strings
+++ b/Development/OpenPassDevelopmentApp/Localizable.strings
@@ -24,7 +24,7 @@
 "root.button.signout" = "Sign Out";
 "root.button.signin" = "Sign In";
 "root.button.refresh" = "Refresh";
-"root.button.daf" = "Sign In (Device Auth)";
+"root.button.daf" = "Sign In\n(Device Auth)";
 
 "root.title.openpassTokens" = "OpenPass Tokens";
 

--- a/Development/OpenPassDevelopmentApp/OpenPassTokensView.swift
+++ b/Development/OpenPassDevelopmentApp/OpenPassTokensView.swift
@@ -26,6 +26,8 @@
 
 import SwiftUI
 
+private let tokenLineLimit = 4
+
 struct OpenPassTokensView: View {
 
     @ObservedObject
@@ -47,6 +49,7 @@ struct OpenPassTokensView: View {
             Text(viewModel.idJWTToken)
                 .font(Font.system(size: 16, weight: .regular))
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(tokenLineLimit)
 
             Text(LocalizedStringKey("root.label.openpassTokens.accessToken"))
                 .font(Font.system(size: 18, weight: .bold))
@@ -54,6 +57,7 @@ struct OpenPassTokensView: View {
             Text(viewModel.accessToken)
                 .font(Font.system(size: 16, weight: .regular))
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(tokenLineLimit)
 
             Text(LocalizedStringKey("root.label.openpassTokens.tokenType"))
                 .font(Font.system(size: 18, weight: .bold))
@@ -75,6 +79,7 @@ struct OpenPassTokensView: View {
             Text(viewModel.refreshToken)
                 .font(Font.system(size: 16, weight: .regular))
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(tokenLineLimit)
 
             Text(LocalizedStringKey("root.label.openpassTokens.email"))
                 .font(Font.system(size: 18, weight: .bold))

--- a/Development/OpenPassDevelopmentApp/RootView.swift
+++ b/Development/OpenPassDevelopmentApp/RootView.swift
@@ -37,42 +37,58 @@ struct RootView: View {
             Text(viewModel.titleText)
                 .font(Font.system(size: 28, weight: .bold))
                 .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+
             if viewModel.error != nil {
                 ErrorListView(viewModel)
             } else {
-                OpenPassTokensView(viewModel)
-                Spacer()
+                ScrollView {
+                    OpenPassTokensView(viewModel)
+                    Spacer()
+                }
             }
             HStack(alignment: .center, spacing: 20.0) {
                 Button(LocalizedStringKey("root.button.signout")) {
                     viewModel.signOut()
-                }.padding()
+                }
+                .padding()
+                .accessibilityIdentifierIfAvailable("signOut")
 
                 #if !os(tvOS)
                 Button(LocalizedStringKey("root.button.signin")) {
                     viewModel.startSignInUXFlow()
-                }.padding()
+                }
+                .padding()
+                .accessibilityIdentifierIfAvailable("signIn")
                 #endif
 
-                if viewModel.canRefreshTokens {
-                    Button(LocalizedStringKey("root.button.refresh")) {
-                        viewModel.refreshTokenFlow()
-                    }.padding()
-                }
-
-                #if os(tvOS)
                 Button(LocalizedStringKey("root.button.daf")) {
                     viewModel.startSignInDAFFlow()
-                }.padding()
-                #endif
+                }
+                .padding()
+                .accessibilityIdentifierIfAvailable("signInDeviceAuth")
             }
-            #if os(tvOS)
-            .sheet(isPresented: $viewModel.showDAF, content: {
-                DeviceAuthorizationView(showDeviceAuthorizationView: $viewModel.showDAF)
-                    .presentationDetents([.medium])
-            })
-            #endif
+
+            if viewModel.canRefreshTokens {
+                HStack {
+                    Button(LocalizedStringKey("root.button.refresh")) {
+                        viewModel.refreshTokenFlow()
+                    }
+                    .padding()
+                }
+            }
         }
-        .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/)
+        .frame(maxWidth: .infinity)
+        .sheet(isPresented: $viewModel.showDAF, content: {
+            DeviceAuthorizationView(showDeviceAuthorizationView: $viewModel.showDAF)
+        })
+    }
+}
+extension View {
+    func accessibilityIdentifierIfAvailable(_ identifier: String) -> some View {
+        if #available(iOS 14.0, *) {
+            return self.accessibilityIdentifier(identifier)
+        } else {
+            return self
+        }
     }
 }

--- a/Development/OpenPassDevelopmentAppUITests/Helpers/MailSlurpClient.swift
+++ b/Development/OpenPassDevelopmentAppUITests/Helpers/MailSlurpClient.swift
@@ -1,0 +1,104 @@
+//
+//  MailSlurpClient.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+@preconcurrency import mailslurp
+import OpenPass
+import SwiftSoup
+
+struct Configuration: Decodable {
+    var mailslurpApiKey: String
+}
+
+@MainActor
+final class MailSlurpClient {
+    private let apiKey: String
+
+    static func withBundleConfiguration() throws -> MailSlurpClient {
+        guard let url = Bundle(for: MailSlurpClient.self).url(forResource: "configuration", withExtension: "json"),
+              let configuration = try? JSONDecoder().decode(Configuration.self, from: Data(contentsOf: url))
+        else {
+            throw ConfigurationError(message: "Missing MailSlurp API key.")
+        }
+        return MailSlurpClient(apiKey: configuration.mailslurpApiKey)
+    }
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    func inbox() async throws -> InboxDto {
+        try await InboxControllerAPI
+            .createInboxWithDefaultsWithRequestBuilder()
+            .setApiKey(apiKey)
+            .execute()
+            .async()
+            .body
+    }
+
+    func delete(_ inbox: InboxDto) async throws {
+        _ = try await InboxControllerAPI
+            .deleteInboxWithRequestBuilder(inboxId: inbox._id)
+            .execute()
+            .async()
+    }
+
+    func latestOTP(from inbox: InboxDto) async throws -> String? {
+        let email = try await latestEmail(from: inbox)
+        guard let body = email.body else {
+            return nil
+        }
+        let doc = try SwiftSoup.parse(body)
+        return try doc.select("#otp-code").first()?.text()
+    }
+
+    private func latestEmail(from inbox: InboxDto) async throws -> Email {
+        try await WaitForControllerAPI
+            .waitForLatestEmailWithRequestBuilder(
+                inboxId: inbox._id,
+                timeout: 40 * 1000,
+                unreadOnly: true,
+                before: nil,
+                since: nil,
+                sort: nil,
+                delay: nil
+            )
+            .setApiKey(apiKey)
+            .execute()
+            .async()
+            .body
+    }
+}
+
+fileprivate extension RequestBuilder {
+    func setApiKey(_ apiKey: String) -> RequestBuilder {
+        addHeader(name: "x-api-key", value: apiKey)
+    }
+}
+
+struct ConfigurationError: Error {
+    var message: String
+}

--- a/Development/OpenPassDevelopmentAppUITests/Helpers/TestHelpers.swift
+++ b/Development/OpenPassDevelopmentAppUITests/Helpers/TestHelpers.swift
@@ -1,0 +1,49 @@
+//
+//  TestHelpers.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import XCTest
+
+/// Taps 'Continue' in an alert presented by the system, typically in response to opening an external auth session
+@MainActor
+func waitForSpringboardAlertAndContinue() {
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    let alert = springboard.alerts.firstMatch
+    if alert.waitForExistence(timeout: 10) {
+        alert.buttons["Continue"].tap()
+    }
+}
+
+extension XCUIElement {
+    /// A convenience for waiting for an element to exist and then performing an action with the element.
+    @discardableResult
+    func waitForExistence(timeout: TimeInterval = webViewTimeout, action: (_ element: XCUIElement) -> Void) -> Bool {
+        if waitForExistence(timeout: timeout) {
+            action(self)
+            return true
+        }
+        return false
+    }
+}

--- a/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-DeviceAuth.xctestplan
+++ b/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-DeviceAuth.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "976F35F5-E807-45BC-9D72-A7084A0F104E",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "skippedTests" : [
+        "OpenPassDevelopmentAppUITests\/testMobileSignIn()"
+      ],
+      "target" : {
+        "containerPath" : "container:OpenPassDevelopmentApp.xcodeproj",
+        "identifier" : "BF4F1F6A2CE2677000D35A5D",
+        "name" : "OpenPassDevelopmentAppUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-Mobile.xctestplan
+++ b/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests-Mobile.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "976F35F5-E807-45BC-9D72-A7084A0F104E",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "skippedTests" : [
+        "OpenPassDevelopmentAppUITests\/testDeviceAuth()"
+      ],
+      "target" : {
+        "containerPath" : "container:OpenPassDevelopmentApp.xcodeproj",
+        "identifier" : "BF4F1F6A2CE2677000D35A5D",
+        "name" : "OpenPassDevelopmentAppUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
+++ b/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
@@ -1,0 +1,255 @@
+//
+//  OpenPassDevelopmentAppUITests.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@preconcurrency import mailslurp
+import XCTest
+
+/// Timeout for page loads.
+/// Most of the sign in flow takes place in a webview, so we're required to wait for network loads etc.
+let webViewTimeout: Double = 30
+
+@MainActor
+final class OpenPassDevelopmentAppUITests: XCTestCase {
+
+    private var inbox: InboxDto?
+
+    override func setUpWithError() throws {
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+    }
+
+    override func tearDown() async throws {
+        if let inbox {
+            do {
+                print("Deleting test inbox.")
+                try await MailSlurpClient.withBundleConfiguration().delete(inbox)
+            } catch {
+                print("Error deleting test inbox.")
+            }
+        }
+    }
+
+    func testMobileSignIn() async throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let client = try MailSlurpClient.withBundleConfiguration()
+
+        // Create the email inbox
+        let inbox = try await client.inbox()
+        self.inbox = inbox
+
+        let devApp = DevApp(app)
+        devApp.signOutButton.waitForExistence {
+            $0.tap()
+        }
+        devApp.signInButton.waitForExistence {
+            $0.tap()
+        }
+
+        // addUIInterruptionMonitor doesn't actually seem to work
+        // https://forums.developer.apple.com/forums/thread/737880
+        // The springboard approach also seems unreliable on some devices.
+        waitForSpringboardAlertAndContinue()
+
+        // Returns multiple matches (three) all for the same single WebView
+        let signInView = SignInView(app.webViews.firstMatch)
+        try await signIn(view: signInView, client: client, inbox: inbox)
+
+        guard app.wait(for: .runningForeground, timeout: webViewTimeout) else {
+            XCTFail("App did not return to foreground")
+            return
+        }
+    }
+
+    func testDeviceAuth() async throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let client = try MailSlurpClient.withBundleConfiguration()
+
+        // Create the email inbox
+        let inbox = try await client.inbox()
+        self.inbox = inbox
+
+        let devApp = DevApp(app)
+        devApp.signOutButton.waitForExistence {
+            $0.tap()
+        }
+        devApp.signInDeviceAuthButton.waitForExistence {
+            $0.tap()
+        }
+
+        // Retrieve the verification URI
+        let text = devApp.verificationUriComplete
+        guard text.waitForExistence(timeout: 5),
+            let authURL = URL(string: text.label) else {
+            XCTFail("Missing or invalid verification URI")
+            return
+        }
+
+        // Open the verification URI in Safari.app
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        safari.open(authURL)
+        guard safari.wait(for: .runningForeground, timeout: 10) else {
+            XCTFail("Failed to launch Safari")
+            return
+        }
+
+        // Confirm that we want to sign in for the 'device'
+        safari.buttons["Accept device registration and continue"].waitForExistence(timeout: webViewTimeout) {
+            $0.tap()
+        }
+
+        // Proceed with sign in process
+        try await signIn(view: SignInView(safari), client: client, inbox: inbox)
+
+        // Return to this dev app
+        app.activate()
+
+        guard app.wait(for: .runningForeground, timeout: webViewTimeout) else {
+            XCTFail("App did not return to foreground")
+            return
+        }
+    }
+
+    func signIn(view signInView: SignInView, client: MailSlurpClient, inbox: InboxDto) async throws {
+        // Ensure the webView is loaded
+        if !signInView.emailInput.waitForExistence(timeout: webViewTimeout) {
+            // If the email address input does not exist, then it's likely that Chrome already has a previous
+            // login session active. We need to click the "Use another email" to clear out the old session
+            signInView.signInWithAnotherEmail.tap()
+        }
+
+        // Ensure the webView is loaded
+        guard signInView.emailInput.waitForExistence(timeout: webViewTimeout) else {
+            XCTFail("Missing email input field")
+            return
+        }
+
+        // Now enter the email address of the MailSlurp inbox into the text input
+        // On a physical device, tapping the input is required before text may be entered
+        signInView.emailInput.tap()
+        signInView.emailInput.typeText(inbox.emailAddress)
+        // Click Continue
+        signInView.emailInputContinue.tap()
+
+        // Now wait for the email containing the OTP
+        guard let code = try await client.latestOTP(from: inbox) else {
+            XCTFail("Failed to parse OTP code from email")
+            return
+        }
+
+        // ...and enter it into the OTP text boxes, ensuring the webView is loaded
+        guard signInView.codeInput.waitForExistence(timeout: webViewTimeout) else {
+            XCTFail("OTP input page failed to load")
+            return
+        }
+        signInView.enterCode(code)
+    }
+
+}
+
+@MainActor
+final class SignInView {
+    private var rootElement: XCUIElement
+
+    init(_ rootElement: XCUIElement) {
+        self.rootElement = rootElement
+    }
+
+    var continueExistingEmail: XCUIElement {
+        rootElement.buttons["Continue with previously verified email address"]
+    }
+
+    var signInWithAnotherEmail: XCUIElement {
+        rootElement.links["Sign In with another email"]
+    }
+
+    var emailInput: XCUIElement {
+        rootElement.textFields["Email address"]
+    }
+
+    var emailInputContinue: XCUIElement {
+        rootElement.buttons["Continue"]
+    }
+
+    /// OTP Code Input suitable for testing existence
+    var codeInput: XCUIElement {
+        codeInput(for: 5)
+    }
+
+    func enterCode(_ code: String) {
+        code.enumerated().forEach { index, char in
+            // On a physical device, tapping the input is required before text may be entered
+            let inputField = codeInput(for: index)
+            inputField.tap()
+            inputField.typeText(String(char))
+        }
+    }
+
+    private func codeInput(for index: Int) -> XCUIElement {
+        assert(index < 6)
+        let labels = [
+            "first",
+            "second",
+            "third",
+            "fourth",
+            "fifth",
+            "sixth"
+        ]
+            .map { word in
+                "Enter verification code \(word) digit"
+            }
+        return rootElement.textFields[labels[index]]
+    }
+}
+
+/// A representation of the Dev App's main screen
+@MainActor
+final class DevApp {
+    private var app: XCUIApplication
+
+    init(_ app: XCUIApplication) {
+        self.app = app
+    }
+
+    var signInButton: XCUIElement {
+        app.buttons["signIn"]
+    }
+
+    var signOutButton: XCUIElement {
+        app.buttons["signOut"]
+    }
+
+    var signInDeviceAuthButton: XCUIElement {
+        app.buttons["signInDeviceAuth"]
+    }
+
+    var verificationUriComplete: XCUIElement {
+        app.staticTexts["verificationUriComplete"]
+    }
+}

--- a/Development/OpenPassDevelopmentAppUITests/configuration.json.tpl
+++ b/Development/OpenPassDevelopmentAppUITests/configuration.json.tpl
@@ -1,0 +1,3 @@
+{
+  "mailslurpApiKey": ""
+}

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>method</key>
+	<string>debugging</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
* Add automated tests for both mobile sign in and 'tv' device auth (on mobile).
* Add UI test target and update scheme test
* Add testplans to configure test runner
* Add MailSlurpClient wrapper
* Remove OS checks and allow device auth flow to run on iOS

Subsequent PRs will configure CI to execute these tests.

To avoid exposing API keys such as the Mailslurp API Key, a configuration file bundled with the tests only is read from disk.

CI/Env will populate this `configuration.json` as follows:

```sh
jq --arg key "$MAIL_SLURP_API_KEY" '.mailslurpApiKey = $key' Development/OpenPassDevelopmentAppUITests/configuration.json.tpl > Development/OpenPassDevelopmentAppUITests/configuration.json
```

To execute the individual tests on the Simulator, using `plutil` to set the appropriate client ID per auth flow:

```sh
# Run the Sign In Flow
plutil -replace OpenPassClientId -string "421d407048794885b2baf4dbcde185cb" Development/OpenPassDevelopmentApp/Info.plist

xcodebuild test \
  -project Development/OpenPassDevelopmentApp.xcodeproj \
  -scheme "Local OpenPassDevelopmentAppUITests" \
  -sdk iphonesimulator18.0 \
  -destination "OS=18.0,name=iPhone 16" \
  -only-testing "OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests/testMobileSignIn"

# Run the Device Auth Flow
plutil -replace OpenPassClientId -string "51c42041a7de48f59bff4f8a8a6ad18b" Development/OpenPassDevelopmentApp/Info.plist 

xcodebuild test \
  -project Development/OpenPassDevelopmentApp.xcodeproj \
  -scheme "Local OpenPassDevelopmentAppUITests" \
  -sdk iphonesimulator18.0 \
  -destination "OS=18.0,name=iPhone 16" \
  -only-testing "OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests/testDeviceAuth"
```

To execute the tests on a physical device, these commands are required:

```sh
# Run the Sign In Flow
plutil -replace OpenPassClientId -string "421d407048794885b2baf4dbcde185cb" Development/OpenPassDevelopmentApp/Info.plist
# Build test runner
xcodebuild build-for-testing \
  -project Development/OpenPassDevelopmentApp.xcodeproj \
  -scheme OpenPassDevelopmentApp \
  -testPlan OpenPassDevelopmentAppUITests-Mobile \
  -derivedDataPath build/derived-data
# Execute test runner 
xcodebuild test-without-building \
  -xctestrun build/derived-data/Build/Products/OpenPassDevelopmentApp_OpenPassDevelopmentAppUITests-Mobile_iphoneos18.0-arm64.xctestrun \
  -derivedDataPath build/derived-data \
  -destination 'platform=iOS,name=<device-name>' \
  -resultBundlePath /tmp/openpass-result-bundle
```

However, BrowserStack also requires an IPA bundle. It is unclear why, but it's easy to produce:

```sh
# Build and archive the dev app
xcodebuild archive \
  -project Development/OpenPassDevelopmentApp.xcodeproj \
  -scheme OpenPassDevelopmentApp \
  -derivedDataPath build/derived-data \
  -archivePath build/OpenPassDevelopmentApp.xcarchive
# Export the dev app archive (build IPA)
xcodebuild -exportArchive \
  -archivePath "build/OpenPassDevelopmentApp.xcarchive" \
  -exportPath "build" \
  -exportOptionsPlist "ExportOptions.plist"
```