### PR TITLE
Allow setting configuration parameters in code

### DIFF
--- a/Sources/OpenPass/OpenPassConfiguration.swift
+++ b/Sources/OpenPass/OpenPassConfiguration.swift
@@ -1,0 +1,70 @@
+//
+//  OpenPassConfiguration.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+struct OpenPassConfiguration: Hashable, Sendable {
+    static let defaultBaseURL = "https://auth.myopenpass.com/"
+
+    /// - Parameters:
+    ///   - baseURL: API base URL. If `nil`, the `defaultBaseURL` is used.
+    ///   - clientId: Application client identifier
+    ///   - redirectHost: The expected redirect host configured for your application
+    init(baseURL: String = defaultBaseURL, clientId: String, redirectHost: String) {
+        self.baseURL = baseURL
+        self.clientId = clientId
+        self.redirectHost = redirectHost
+    }
+
+    /// Initializes a Configuration reading from the `Info.plist` first, and falling back to `OpenPassSettings`, if any.
+    init() {
+        if let baseURLOverride = Bundle.main.object(forInfoDictionaryKey: "OpenPassBaseURL") as? String, !baseURLOverride.isEmpty {
+            self.baseURL = baseURLOverride
+        } else {
+            self.baseURL = Self.defaultBaseURL
+        }
+
+        if let bundleClientId = Bundle.main.object(forInfoDictionaryKey: "OpenPassClientId") as? String {
+            self.clientId = bundleClientId
+        } else if let settingsClientId = OpenPassSettings.shared.clientId {
+            self.clientId = settingsClientId
+        } else {
+            self.clientId = ""
+        }
+
+        if let bundleRedirectHost = Bundle.main.object(forInfoDictionaryKey: "OpenPassRedirectHost") as? String {
+            self.redirectHost = bundleRedirectHost
+        } else if let settingsRedirectHost = OpenPassSettings.shared.redirectHost {
+            self.redirectHost = settingsRedirectHost
+        } else {
+            self.redirectHost = ""
+        }
+    }
+
+    var baseURL: String
+    var clientId: String
+    var redirectHost: String
+}

--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -35,7 +35,7 @@ public final class OpenPassManager {
     
     /// Singleton access point for OpenPassManager.
     public static let shared = OpenPassManager()
-    
+
     /// User data for the OpenPass user currently signed in.
     public private(set) var openPassTokens: OpenPassTokens?
     
@@ -44,8 +44,6 @@ public final class OpenPassManager {
     /// OpenPass Server URL for Web UX and API Server
     /// Override default by setting `OpenPassBaseURL` in app's Info.plist
     private let baseURL: String
-
-    private static let defaultBaseURL = "https://auth.myopenpass.com/"
 
     /// OpenPass Client Identifier
     /// Set `OpenPassClientId` in app's Info.plist
@@ -88,49 +86,27 @@ public final class OpenPassManager {
     /// Internal dependency
     private let clock: Clock
 
-    /// Singleton Constructor for parsing Info.plist configuration.
-    private convenience init() {
-        let baseURL: String
-        if let baseURLOverride = Bundle.main.object(forInfoDictionaryKey: "OpenPassBaseURL") as? String, !baseURLOverride.isEmpty {
-            baseURL = baseURLOverride
-        } else {
-            baseURL = Self.defaultBaseURL
-        }
-
-        let clientId = Bundle.main.object(forInfoDictionaryKey: "OpenPassClientId") as? String
-        let redirectHost = Bundle.main.object(forInfoDictionaryKey: "OpenPassRedirectHost") as? String
-
-        self.init(
-            baseURL: baseURL,
-            clientId: clientId ?? "",
-            redirectHost: redirectHost ?? ""
-        )
-    }
-
     /// This initializer is internal for testing.
     /// - Parameters:
-    ///   - baseURL: API base URL. If `nil`, the `defaultBaseURL` is used.
-    ///   - clientId: Application client identifier
-    ///   - redirectHost: The expected redirect host configured for your application
+    ///   - configuration: API and request parameters
     ///   - authenticationSession: Provides an authentication session. The default is to use a web based authentication session.
     ///   - authenticationStateGenerator: Authentication state generator. Defaults to a random string.
     ///   - tokenValidator: ID Token validator
+    ///   - clock: Clock implementation
     internal init(
-        baseURL: String? = nil,
-        clientId: String,
-        redirectHost: String,
+        configuration: OpenPassConfiguration = OpenPassConfiguration(),
         authenticationSession: AuthenticationSession = WebAuthenticationSession(),
         authenticationStateGenerator: RandomStringGenerator = .init { randomString(length: 32) },
         tokenValidator: IDTokenValidation? = nil,
         clock: Clock = RealClock()
     ) {
         // These are also validated in `beginSignInUXFlow`
-        assert(!clientId.isEmpty, "Missing `OpenPassClientId` in Info.plist")
-        assert(!redirectHost.isEmpty, "Missing `OpenPassRedirectHost` in Info.plist")
+        assert(!configuration.clientId.isEmpty, "Missing `OpenPassClientId` in Info.plist")
+        assert(!configuration.redirectHost.isEmpty, "Missing `OpenPassRedirectHost` in Info.plist")
         baseRequestParameters = BaseRequestParameters(sdkName: sdkName, sdkVersion: sdkVersion)
-        self.baseURL = baseURL ?? Self.defaultBaseURL
-        self.clientId = clientId
-        self.redirectHost = redirectHost
+        self.baseURL = configuration.baseURL
+        self.clientId = configuration.clientId
+        self.redirectHost = configuration.redirectHost
 
         self.openPassClient = OpenPassClient(
             baseURL: self.baseURL,

--- a/Sources/OpenPass/OpenPassSettings.swift
+++ b/Sources/OpenPass/OpenPassSettings.swift
@@ -1,0 +1,79 @@
+//
+//  OpenPassSettings.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+/// An interface for configuring `OpenPassManager` behavior.
+/// These settings must be configured before calling `OpenPassManager.shared` as they are read when it is initialized.
+/// Subsequent changes will be ignored.
+@objc
+public final class OpenPassSettings: NSObject, @unchecked Sendable {
+
+    // A simple synchronization queue.
+    // We do not expect settings values to be modified frequently, or after SDK initialization.
+    private let queue = DispatchQueue(label: "OpenPassSettings.sync")
+
+    private var _clientId: String?
+
+    /// OpenPass client identifier. The default value is `nil`.
+    /// Setting this value is equivalent to providing a value for `OpenPassClientId` in your Info.plist,
+    /// however any value in the Info.plist will override this one.
+    @objc
+    public var clientId: String? {
+        get {
+            queue.sync {
+                _clientId
+            }
+        }
+        set {
+            queue.sync {
+                _clientId = newValue
+            }
+        }
+    }
+
+    private var _redirectHost: String?
+
+    /// OpenPass sign in redirect host. The default value is `nil`.
+    /// Setting this value is equivalent to providing a value for `OpenPassRedirectHost` in your Info.plist,
+    /// however any value in the Info.plist will override this one.
+    @objc
+    public var redirectHost: String? {
+        get {
+            queue.sync {
+                _redirectHost
+            }
+        }
+        set {
+            queue.sync {
+                _redirectHost = newValue
+            }
+        }
+    }
+
+    @objc
+    public static let shared = OpenPassSettings()
+}


### PR DESCRIPTION
Allow configuration of client identifier and redirect host in code, in addition to `Info.plist`.

e.g.
```
OpenPassSettings.shared.clientId = "421d407048794885b2baf4dbcde185cb"
OpenPassSettings.shared.redirectHost = "com.myopenpass.devapp"
```
