### PR TITLE
Add Objective-C support

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -32,11 +32,23 @@ jobs:
       - name: Build for tvOS
         run: xcodebuild -scheme OpenPass -destination "generic/platform=tvOS"
 
+      - name: Build ObjC for iOS
+        run: xcodebuild -scheme OpenPassObjC -destination "generic/platform=iOS"
+      
+      - name: Build ObjC for tvOS
+        run: xcodebuild -scheme OpenPassObjC -destination "generic/platform=tvOS"
+
       - name: Run unit tests on iOS
         run: xcodebuild test -scheme OpenPass -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
 
       - name: Run unit tests on tvOS
         run: xcodebuild test -scheme OpenPass -sdk appletvsimulator17.4 -destination "OS=17.4,name=Apple TV"
+
+      - name: Run ObjC unit tests on iOS
+        run: xcodebuild test -scheme OpenPassObjC -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
+
+      - name: Run ObjC unit tests on tvOS
+        run: xcodebuild test -scheme OpenPassObjC -sdk appletvsimulator17.4 -destination "OS=17.4,name=Apple TV"
 
       - name: Lint pod spec
         run: pod lib lint --verbose

--- a/.swiftpm/xcode/xcshareddata/xcschemes/OpenPass-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/OpenPass-Package.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPass"
+               BuildableName = "OpenPass"
+               BlueprintName = "OpenPass"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPassObjC"
+               BuildableName = "OpenPassObjC"
+               BlueprintName = "OpenPassObjC"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPassObjCTests"
+               BuildableName = "OpenPassObjCTests"
+               BlueprintName = "OpenPassObjCTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPassTests"
+               BuildableName = "OpenPassTests"
+               BlueprintName = "OpenPassTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "OpenPass"
+            BuildableName = "OpenPass"
+            BlueprintName = "OpenPass"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/OpenPassObjC.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/OpenPassObjC.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPassObjC"
+               BuildableName = "OpenPassObjC"
+               BlueprintName = "OpenPassObjC"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenPassObjCTests"
+               BuildableName = "OpenPassObjCTests"
+               BlueprintName = "OpenPassObjCTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "OpenPassObjC"
+            BuildableName = "OpenPassObjC"
+            BlueprintName = "OpenPassObjC"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,10 @@ let package = Package(
         .library(
             name: "OpenPass",
             targets: ["OpenPass"]
+        ),
+        .library(
+            name: "OpenPassObjC",
+            targets: ["OpenPassObjC"]
         )
     ],
     dependencies: [],
@@ -51,6 +55,21 @@ let package = Package(
             resources: [
                 .copy("TestData")
             ]
+        ),
+        .target(
+            name: "OpenPassObjC",
+            dependencies: ["OpenPass"],
+            path: "Sources/OpenPassObjC",
+            publicHeadersPath: "./"
+        ),
+        .testTarget(
+            name: "OpenPassObjCTests",
+            dependencies: ["OpenPassObjC", "OpenPass", "ObjCTestHelpers"]
+        ),
+        .target(
+            name: "ObjCTestHelpers",
+            dependencies: ["OpenPass", "OpenPassObjC"],
+            path: "Tests/ObjCTestHelpers"
         )
     ],
     swiftLanguageVersions: [.v5])

--- a/Sources/OpenPass/OpenPassManager.swift
+++ b/Sources/OpenPass/OpenPassManager.swift
@@ -258,6 +258,8 @@ public final class OpenPassManager {
         }
     }
 
+    /// Returns a client flow for authorization with an external device.
+    /// The client will automatically updated the OpenPassManager's `openPassTokens` if it is successful in refreshing tokens.
     public var deviceAuthorizationFlow: DeviceAuthorizationFlow {
         DeviceAuthorizationFlow(
             openPassClient: openPassClient,

--- a/Sources/OpenPassObjC/DeviceAuthorizationFlowObjC.swift
+++ b/Sources/OpenPassObjC/DeviceAuthorizationFlowObjC.swift
@@ -1,0 +1,62 @@
+//
+//  DeviceAuthorizationFlowObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+@objc
+public final class DeviceAuthorizationFlowObjC: NSObject {
+    private var deviceAuthorizationFlow: DeviceAuthorizationFlow
+
+    init(deviceAuthorizationFlow: DeviceAuthorizationFlow) {
+        self.deviceAuthorizationFlow = deviceAuthorizationFlow
+    }
+
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+
+    /// Start the authorization flow by requesting a Device Code from the API server.
+    /// The ``DeviceCodeObjC`` contains values for presentation in your user interface.
+    /// A  ``DeviceCodeObjC`` is also used with the `fetchAccessToken(deviceCode:)` method to check for authorization.
+    /// - Returns: A Device Code representation
+    @objc
+    public func fetchDeviceCode() async throws -> DeviceCodeObjC {
+        let deviceCode = try await deviceAuthorizationFlow.fetchDeviceCode()
+        return DeviceCodeObjC(deviceCode)
+    }
+
+    /// Fetch an access token, polling until authorized.
+    /// If the token expires, `OpenPassError.tokenExpired` is thrown. In this case, a new device code should be fetched.
+    /// - Note: If a network error is throw, polling will cease. You will need to check for this error and resume polling as appropriate.
+    /// - Returns: OpenPassTokens
+    @objc
+    public func fetchAccessToken(deviceCode deviceCodeWrapper: DeviceCodeObjC) async throws -> OpenPassTokensObjC {
+        let tokens = try await deviceAuthorizationFlow.fetchAccessToken(deviceCode: deviceCodeWrapper.deviceCode)
+        return OpenPassTokensObjC(tokens)
+    }
+}

--- a/Sources/OpenPassObjC/DeviceCodeObjC.swift
+++ b/Sources/OpenPassObjC/DeviceCodeObjC.swift
@@ -1,0 +1,87 @@
+//
+//  DeviceCodeObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+/// The information required to prompt the user to authenticate via a separate device.
+@objc
+public final class DeviceCodeObjC: NSObject {
+    var deviceCode: DeviceCode
+
+    /// The code that the user is required to enter at the location defined by the verification uri.
+    @objc
+    public var userCode: String {
+        deviceCode.userCode
+    }
+
+    /// The uri the user is required to navigate to and enter the provided code.
+    @objc
+    public var verificationUri: String {
+        deviceCode.verificationUri
+    }
+
+    /// The complete uri that includes the verification address as well as the code. This can be used to generate a QR
+    /// code for the user to use, to simplify navigation.
+    @objc
+    public var verificationUriComplete: String? {
+        deviceCode.verificationUriComplete
+    }
+
+    /// The Date when the user code expires.
+    @objc
+    public var expiresAt: Date {
+        deviceCode.expiresAt
+    }
+
+    init(_ deviceCode: DeviceCode) {
+        self.deviceCode = deviceCode
+    }
+
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+}
+
+// MARK: - Equatable
+
+extension DeviceCodeObjC {
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return deviceCode == other.deviceCode
+    }
+}
+
+// MARK: - Hashable
+
+extension DeviceCodeObjC {
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(deviceCode)
+        return hasher.finalize()
+    }
+}

--- a/Sources/OpenPassObjC/IDTokenObjC.swift
+++ b/Sources/OpenPassObjC/IDTokenObjC.swift
@@ -1,0 +1,132 @@
+//
+//  IDTokenObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+// IDToken
+public final class IDTokenObjC: NSObject {
+    var idToken: IDToken
+
+    // MARK: - IDToken Header Data
+    /// ID of the key used to sign the token
+    @objc
+    public var keyId: String {
+        idToken.keyId
+    }
+
+    /// Type of token
+    @objc
+    public var tokenType: String {
+        idToken.tokenType
+    }
+
+    /// Signing algorithm used
+    @objc
+    public var algorithm: String {
+        idToken.algorithm
+    }
+
+    // MARK: - IDToken Payload Data
+
+    /// ID Token - Issue Identifier
+    @objc
+    public var issuerIdentifier: String {
+        idToken.issuerIdentifier
+    }
+
+    /// ID Token - Subject Identifier
+    @objc
+    public var subjectIdentifier: String {
+        idToken.subjectIdentifier
+    }
+
+    /// ID Token - Audience
+    @objc
+    public var audience: String {
+        idToken.audience
+    }
+
+    /// ID Token - Expiration Time in milliseconds
+    @objc
+    public var expirationTime: NSNumber {
+        NSNumber(value: idToken.expirationTime)
+    }
+
+    /// ID Token - Issued At Time in milliseconds
+    @objc
+    public var issuedTime: NSNumber {
+        NSNumber(value: idToken.issuedTime)
+    }
+
+    // MARK: - OpenPass Data
+
+    /// Email address provided by user
+    @objc
+    public var email: String? {
+        idToken.email
+    }
+
+    /// Given name provided by user
+    @objc
+    public var givenName: String? {
+        idToken.givenName
+    }
+
+    /// Family name provided by user
+    @objc
+    public var familyName: String? {
+        idToken.familyName
+    }
+
+    init(_ idToken: IDToken) {
+        self.idToken = idToken
+    }
+    
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+}
+
+// MARK: - Equatable
+
+extension IDTokenObjC {
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return idToken == other.idToken
+    }
+}
+
+// MARK: - Hashable
+
+extension IDTokenObjC {
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(idToken)
+        return hasher.finalize()
+    }
+}

--- a/Sources/OpenPassObjC/OpenPassManagerObjC.swift
+++ b/Sources/OpenPassObjC/OpenPassManagerObjC.swift
@@ -1,0 +1,97 @@
+//
+//  OpenPassManagerObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+@MainActor
+@objc
+public final class OpenPassManagerObjC: NSObject {
+
+    private let manager = OpenPassManager.shared
+
+    @objc
+    public static let shared = OpenPassManagerObjC()
+
+    private override init() {
+        super.init()
+    }
+
+    /// User data for the OpenPass user currently signed in.
+    @objc
+    public var openPassTokens: OpenPassTokensObjC? {
+        manager.openPassTokens.map(OpenPassTokensObjC.init)
+    }
+
+    /// Starts the OpenID Connect (OAuth) Authentication User Interface Flow.
+    @objc
+    public func beginSignInUXFlow() async throws -> OpenPassTokensObjC {
+        let tokens = try await manager.beginSignInUXFlow()
+        return OpenPassTokensObjC(tokens)
+    }
+
+    /// Signs user out by clearing all sign-in data currently in SDK.  This includes keychain and in-memory data.
+    @objc
+    @discardableResult
+    public func signOut() -> Bool {
+        manager.signOut()
+    }
+
+    /// Returns a client flow for refreshing tokens.
+    /// The client will automatically updated the OpenPassManager's `openPassTokens` if it is successful in refreshing tokens.
+    ///
+    ///     RefreshTokenFlowObjC *flow = OpenPassManagerObjC.shared.refreshTokenFlow;
+    ///     [flow refreshTokens:refreshToken completionHandler:^(OpenPassTokensObjC * _Nullable tokens, NSError * _Nullable error) {
+    ///         dispatch_async(dispatch_get_main_queue(), ^{
+    ///             // Update UI
+    ///         });
+    ///     }];
+    @objc
+    public var refreshTokenFlow: RefreshTokenFlowObjC {
+        RefreshTokenFlowObjC(refreshTokenFlow: manager.refreshTokenFlow)
+    }
+
+    /// Returns a client flow for authorization with an external device.
+    /// The client will automatically updated the OpenPassManager's `openPassTokens` if it is successful in refreshing tokens.
+    ///
+    ///     DeviceAuthorizationFlowObjC *flow = [OpenPassManagerObjC.shared deviceAuthorizationFlow];
+    ///     [flow fetchDeviceCodeWithCompletionHandler:^(DeviceCodeObjC * _Nullable deviceCode, NSError * _Nullable error) {
+    ///         if (deviceCode) {
+    ///             // Present UI with device code information
+    ///             // i.e. deviceCode.userCode, deviceCode.verificationUriComplete
+    ///
+    ///             [flow fetchAccessTokenWithDeviceCode:deviceCode completionHandler:^(OpenPassTokensObjC * _Nullable tokens, NSError * _Nullable error) {
+    ///                 dispatch_async(dispatch_get_main_queue(), ^{
+    ///                     // Update UI
+    ///                 });
+    ///             }];
+    ///         }
+    ///     }];
+    @objc
+    public var deviceAuthorizationFlow: DeviceAuthorizationFlowObjC {
+        DeviceAuthorizationFlowObjC(deviceAuthorizationFlow: manager.deviceAuthorizationFlow)
+    }
+}

--- a/Sources/OpenPassObjC/OpenPassTokensObjC.swift
+++ b/Sources/OpenPassObjC/OpenPassTokensObjC.swift
@@ -1,0 +1,115 @@
+//
+//  OpenPassTokensObjc.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+@objc
+public final class OpenPassTokensObjC: NSObject {
+    var openPassTokens: OpenPassTokens
+
+    /// ID Token constructed via `idTokenJWT`
+    @objc
+    public var idToken: IDTokenObjC? {
+        openPassTokens.idToken.map(IDTokenObjC.init)
+    }
+
+    /// ID token as JWT
+    @objc
+    public var idTokenJWT: String {
+        openPassTokens.idTokenJWT
+    }
+
+    /// Seconds until the ID Token expires
+    @objc
+    public var idTokenExpiresIn: NSNumber? {
+        openPassTokens.idTokenExpiresIn.map(NSNumber.init(value: ))
+    }
+
+    /// Access Token
+    @objc
+    public var accessToken: String {
+        openPassTokens.accessToken
+    }
+
+    /// Type of Access Token
+    @objc
+    public var tokenType: String {
+        openPassTokens.tokenType
+    }
+
+    /// Seconds until the Access Token expires
+    @objc
+    public var expiresIn: Int64 {
+        openPassTokens.expiresIn
+    }
+
+    /// Refresh Token
+    @objc
+    public var refreshToken: String? {
+        openPassTokens.refreshToken
+    }
+
+    /// Seconds until the Refresh Token expires
+    @objc
+    public var refreshTokenExpiresIn: NSNumber? {
+        openPassTokens.refreshTokenExpiresIn.map(NSNumber.init(value: ))
+    }
+
+    /// Instant when tokens were issued
+    @objc
+    public var issuedAt: Date? {
+        openPassTokens.issuedAt
+    }
+
+    init(_ openPassTokens: OpenPassTokens) {
+        self.openPassTokens = openPassTokens
+    }
+
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+}
+
+// MARK: - Equatable
+
+extension OpenPassTokensObjC {
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return openPassTokens == other.openPassTokens
+    }
+}
+
+// MARK: - Hashable
+
+extension OpenPassTokensObjC {
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(openPassTokens)
+        return hasher.finalize()
+    }
+}

--- a/Sources/OpenPassObjC/RefreshTokenFlowObjC.swift
+++ b/Sources/OpenPassObjC/RefreshTokenFlowObjC.swift
@@ -1,0 +1,48 @@
+//
+//  RefreshTokenFlowObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+@objc
+public final class RefreshTokenFlowObjC: NSObject {
+    private var refreshTokenFlow: RefreshTokenFlow
+
+    init(refreshTokenFlow: RefreshTokenFlow) {
+        self.refreshTokenFlow = refreshTokenFlow
+    }
+
+    @available(*, unavailable)
+    public override init() {
+        fatalError()
+    }
+    
+    @objc
+    public func refreshTokens(_ refreshToken: String) async throws -> OpenPassTokensObjC {
+        let tokens = try await refreshTokenFlow.refreshTokens(refreshToken)
+        return OpenPassTokensObjC(tokens)
+    }
+}

--- a/Tests/ObjCTestHelpers/DeviceCodeObjC.swift
+++ b/Tests/ObjCTestHelpers/DeviceCodeObjC.swift
@@ -1,0 +1,52 @@
+//
+//  DeviceCodeObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+@testable import OpenPass
+@testable import OpenPassObjC
+
+@objc
+extension DeviceCodeObjC {
+    @objc
+    public convenience init(
+        userCode: String,
+        verificationUri: String,
+        verificationUriComplete: String? = nil,
+        expiresAt: Date,
+        deviceCode: String,
+        interval: Int64
+    ) {
+        let deviceCode = DeviceCode(
+            userCode: userCode,
+            verificationUri: verificationUri,
+            verificationUriComplete: verificationUriComplete,
+            expiresAt: expiresAt,
+            deviceCode: deviceCode,
+            interval: interval
+        )
+        self.init(deviceCode)
+    }
+}

--- a/Tests/ObjCTestHelpers/IDTokenObjC.swift
+++ b/Tests/ObjCTestHelpers/IDTokenObjC.swift
@@ -1,0 +1,64 @@
+//
+//  IDTokenObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+@testable import OpenPass
+@testable import OpenPassObjC
+
+@objc
+extension IDTokenObjC {
+    @objc
+    public convenience init(
+        idTokenJWT: String,
+        keyId: String,
+        tokenType: String,
+        algorithm: String,
+        issuerIdentifier: String,
+        subjectIdentifier: String,
+        audience: String,
+        expirationTime: Int,
+        issuedTime: Int,
+        email: String? = nil,
+        givenName: String? = nil,
+        familyName: String? = nil
+    ) {
+        let token = IDToken(
+            idTokenJWT: idTokenJWT,
+            keyId: keyId,
+            tokenType: tokenType,
+            algorithm: algorithm,
+            issuerIdentifier: issuerIdentifier,
+            subjectIdentifier: subjectIdentifier,
+            audience: audience,
+            expirationTime: Int64(expirationTime),
+            issuedTime: Int64(issuedTime),
+            email: email,
+            givenName: givenName,
+            familyName: familyName
+        )
+        self.init(token)
+    }
+}

--- a/Tests/ObjCTestHelpers/OpenPassTokensObjC.swift
+++ b/Tests/ObjCTestHelpers/OpenPassTokensObjC.swift
@@ -1,0 +1,56 @@
+//
+//  OpenPassTokensObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+    
+import Foundation
+@testable import OpenPass
+@testable import OpenPassObjC
+
+@objc
+extension OpenPassTokensObjC {
+    @objc
+    public convenience init(
+        idTokenJWT: String,
+        idTokenExpiresIn: NSNumber?,
+        accessToken: String,
+        tokenType: String,
+        expiresIn: Int,
+        refreshToken: String?,
+        refreshTokenExpiresIn: NSNumber?,
+        issuedAt: Date?
+    ) {
+        let tokens = OpenPassTokens(
+            idTokenJWT: idTokenJWT,
+            idTokenExpiresIn: idTokenExpiresIn?.int64Value,
+            accessToken: accessToken,
+            tokenType: tokenType,
+            expiresIn: Int64(expiresIn),
+            refreshToken: refreshToken,
+            refreshTokenExpiresIn: refreshTokenExpiresIn?.int64Value,
+            issuedAt: issuedAt
+        )
+        self.init(tokens)
+    }
+}

--- a/Tests/OpenPassObjCTests/DeviceCodeObjCTests.m
+++ b/Tests/OpenPassObjCTests/DeviceCodeObjCTests.m
@@ -1,0 +1,69 @@
+//
+//  DeviceCodeObjCTests.m
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@import OpenPassObjC;
+@import ObjCTestHelpers;
+@import XCTest;
+
+@interface DeviceCodeObjCTests : XCTestCase
+
+@end
+
+@implementation DeviceCodeObjCTests
+
+// Returns a new Object
+- (DeviceCodeObjC *)deviceCodeWrapper
+{
+    return [[DeviceCodeObjC alloc] initWithUserCode:@"user_code"
+                                    verificationUri:@"http://example.com/verify"
+                            verificationUriComplete:@"http://example.com/verify?code=device_code"
+                                          expiresAt:[NSDate dateWithTimeIntervalSince1970: 3]
+                                         deviceCode:@"device_code"
+                                           interval:5];
+}
+
+- (void)testWrapper
+{
+    DeviceCodeObjC *deviceCode = [self deviceCodeWrapper];
+
+    XCTAssertEqualObjects(deviceCode.expiresAt, [NSDate dateWithTimeIntervalSince1970: 3]);
+    XCTAssertEqualObjects(deviceCode.userCode, @"user_code");
+    XCTAssertEqualObjects(deviceCode.verificationUri, @"http://example.com/verify");
+    XCTAssertEqualObjects(deviceCode.verificationUriComplete, @"http://example.com/verify?code=device_code");
+}
+
+- (void)testHashableEquatable
+{
+    DeviceCodeObjC *first = [self deviceCodeWrapper];
+    XCTAssertEqualObjects(first, first);
+    XCTAssertEqual(first.hash, first.hash);
+
+    DeviceCodeObjC *second = [self deviceCodeWrapper];
+    XCTAssertEqualObjects(first, second);
+    XCTAssertEqual(first.hash, second.hash);
+}
+
+@end

--- a/Tests/OpenPassObjCTests/IDTokenObjCTests.m
+++ b/Tests/OpenPassObjCTests/IDTokenObjCTests.m
@@ -1,0 +1,83 @@
+//
+//  IDTokenObjCTests.m
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@import OpenPassObjC;
+@import ObjCTestHelpers;
+@import XCTest;
+
+@interface IDTokenObjCTests : XCTestCase
+
+@end
+
+@implementation IDTokenObjCTests
+
+// Returns a new Object
+- (IDTokenObjC *)tokenWrapper
+{
+    NSString *JWT = @"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc2N2I5MjI1NDQ2MTNmNGMzNWI0ZGFhNjQ2YmJjNjRhYzQ3M2Q2ZjI2ZmEzZDZhMmIzODcxMjk1MmQ5MWJhNzMiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxYzYzMDljOS1iZWFlLTRjM2ItOWY5Yi0zNzA3Njk5NmQ4YTYiLCJhdWQiOiIyOTM1MjkxNTk4MjM3NDIzOTg1NyIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODg4OCIsImV4cCI6MTY3NDQwODA2MCwiaWF0IjoxNjcxODE2MDYwLCJlbWFpbCI6ImZvb0BiYXIuY29tIiwiZ2l2ZW5fbmFtZSI6IkpvaG4iLCJmYW1pbHlfbmFtZSI6IkRvZSJ9.kknysH8DD6rCOjhYQhW-gai72yyw-8zEW_-bQlwgztwBfiCBtKR2kXb5q3-tNQf_MQENiUaZ4O-x3PvXJPRLIoox5NuHlmdOQHVOlBfpUDgq1unAq1D5RO5YIi1jnl6IImDNZu5rzYs2Hj8mayJ8B8sZc174zilLVyHxIiKuA5EPKOUyrTsEx7D6SrId0KJ0S9TLkAv3ZpUfsxLrxoTnRU71WO88prkB2N51Z3k8-L-oyKzOk50g_otMt4EvCIQlmn5upIGZH5mKYOow1DOVv-XuVByoikXy6HKsT8zD9iC_vqlaPtJtRctPQMox7qrlee-2BXvWchwMUDVY4NzkhA";
+
+    return [[IDTokenObjC alloc] initWithIdTokenJWT:JWT
+                                             keyId:@"767b922544613f4c35b4daa646bbc64ac473d6f26fa3d6a2b38712952d91ba73"
+                                         tokenType:@"JWT"
+                                         algorithm:@"RS256"
+                                  issuerIdentifier:@"http://localhost:8888"
+                                 subjectIdentifier:@"1c6309c9-beae-4c3b-9f9b-37076996d8a6"
+                                          audience:@"29352915982374239857"
+                                    expirationTime:1674408060
+                                        issuedTime:1671816060
+                                             email:@"foo@bar.com"
+                                         givenName:@"John"
+                                        familyName:@"Doe"];
+}
+
+- (void)testWrapper
+{
+    IDTokenObjC *token = [self tokenWrapper];
+    XCTAssertEqualObjects(token.keyId, @"767b922544613f4c35b4daa646bbc64ac473d6f26fa3d6a2b38712952d91ba73");
+    XCTAssertEqualObjects(token.tokenType, @"JWT");
+    XCTAssertEqualObjects(token.algorithm, @"RS256");
+    XCTAssertEqualObjects(token.issuerIdentifier, @"http://localhost:8888");
+    XCTAssertEqualObjects(token.subjectIdentifier, @"1c6309c9-beae-4c3b-9f9b-37076996d8a6");
+    XCTAssertEqualObjects(token.audience, @"29352915982374239857");
+    XCTAssertEqualObjects(token.expirationTime, @1674408060);
+    XCTAssertEqualObjects(token.issuedTime, @1671816060);
+    XCTAssertEqualObjects(token.email, @"foo@bar.com");
+    XCTAssertEqualObjects(token.givenName, @"John");
+    XCTAssertEqualObjects(token.familyName, @"Doe");
+}
+
+- (void)testHashableEquatable
+{
+    IDTokenObjC *first = [self tokenWrapper];
+    XCTAssertEqualObjects(first, first);
+    XCTAssertEqual(first.hash, first.hash);
+
+    IDTokenObjC *second = [self tokenWrapper];
+    XCTAssertEqualObjects(first, second);
+    XCTAssertEqual(first.hash, second.hash);
+}
+
+@end

--- a/Tests/OpenPassObjCTests/OpenPassTokensObjCTests.m
+++ b/Tests/OpenPassObjCTests/OpenPassTokensObjCTests.m
@@ -1,0 +1,75 @@
+//
+//  OpenPassTokensObjCTests.m
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@import OpenPassObjC;
+@import ObjCTestHelpers;
+@import XCTest;
+
+@interface OpenPassTokensObjCTests : XCTestCase
+
+@end
+
+@implementation OpenPassTokensObjCTests
+
+- (OpenPassTokensObjC *)tokensWrapper
+{
+    NSString *JWT = @"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc2N2I5MjI1NDQ2MTNmNGMzNWI0ZGFhNjQ2YmJjNjRhYzQ3M2Q2ZjI2ZmEzZDZhMmIzODcxMjk1MmQ5MWJhNzMiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxYzYzMDljOS1iZWFlLTRjM2ItOWY5Yi0zNzA3Njk5NmQ4YTYiLCJhdWQiOiIyOTM1MjkxNTk4MjM3NDIzOTg1NyIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODg4OCIsImV4cCI6MTY3NDQwODA2MCwiaWF0IjoxNjcxODE2MDYwLCJlbWFpbCI6ImZvb0BiYXIuY29tIiwiZ2l2ZW5fbmFtZSI6IkpvaG4iLCJmYW1pbHlfbmFtZSI6IkRvZSJ9.kknysH8DD6rCOjhYQhW-gai72yyw-8zEW_-bQlwgztwBfiCBtKR2kXb5q3-tNQf_MQENiUaZ4O-x3PvXJPRLIoox5NuHlmdOQHVOlBfpUDgq1unAq1D5RO5YIi1jnl6IImDNZu5rzYs2Hj8mayJ8B8sZc174zilLVyHxIiKuA5EPKOUyrTsEx7D6SrId0KJ0S9TLkAv3ZpUfsxLrxoTnRU71WO88prkB2N51Z3k8-L-oyKzOk50g_otMt4EvCIQlmn5upIGZH5mKYOow1DOVv-XuVByoikXy6HKsT8zD9iC_vqlaPtJtRctPQMox7qrlee-2BXvWchwMUDVY4NzkhA";
+    return [[OpenPassTokensObjC alloc] initWithIdTokenJWT:JWT
+                                         idTokenExpiresIn:@1
+                                              accessToken:@"access_token"
+                                                tokenType:@"token_type"
+                                                expiresIn:3
+                                             refreshToken:@"refresh_token"
+                                    refreshTokenExpiresIn:@5
+                                                 issuedAt:[NSDate dateWithTimeIntervalSince1970: 7]];
+}
+
+- (void)testWrapper
+{
+    OpenPassTokensObjC *tokens = [self tokensWrapper];
+
+    XCTAssertEqualObjects(tokens.idTokenJWT,  @"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc2N2I5MjI1NDQ2MTNmNGMzNWI0ZGFhNjQ2YmJjNjRhYzQ3M2Q2ZjI2ZmEzZDZhMmIzODcxMjk1MmQ5MWJhNzMiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxYzYzMDljOS1iZWFlLTRjM2ItOWY5Yi0zNzA3Njk5NmQ4YTYiLCJhdWQiOiIyOTM1MjkxNTk4MjM3NDIzOTg1NyIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODg4OCIsImV4cCI6MTY3NDQwODA2MCwiaWF0IjoxNjcxODE2MDYwLCJlbWFpbCI6ImZvb0BiYXIuY29tIiwiZ2l2ZW5fbmFtZSI6IkpvaG4iLCJmYW1pbHlfbmFtZSI6IkRvZSJ9.kknysH8DD6rCOjhYQhW-gai72yyw-8zEW_-bQlwgztwBfiCBtKR2kXb5q3-tNQf_MQENiUaZ4O-x3PvXJPRLIoox5NuHlmdOQHVOlBfpUDgq1unAq1D5RO5YIi1jnl6IImDNZu5rzYs2Hj8mayJ8B8sZc174zilLVyHxIiKuA5EPKOUyrTsEx7D6SrId0KJ0S9TLkAv3ZpUfsxLrxoTnRU71WO88prkB2N51Z3k8-L-oyKzOk50g_otMt4EvCIQlmn5upIGZH5mKYOow1DOVv-XuVByoikXy6HKsT8zD9iC_vqlaPtJtRctPQMox7qrlee-2BXvWchwMUDVY4NzkhA");
+    XCTAssertEqualObjects(tokens.idTokenExpiresIn, @1);
+    XCTAssertEqualObjects(tokens.accessToken, @"access_token");
+    XCTAssertEqualObjects(tokens.tokenType, @"token_type");
+    XCTAssertEqual(tokens.expiresIn, 3);
+    XCTAssertEqualObjects(tokens.refreshToken, @"refresh_token");
+    XCTAssertEqualObjects(tokens.refreshTokenExpiresIn, @5);
+    XCTAssertEqualObjects(tokens.issuedAt, [NSDate dateWithTimeIntervalSince1970: 7]);
+}
+
+- (void)testHashableEquatable
+{
+    OpenPassTokensObjC *first  = [self tokensWrapper];
+    XCTAssertEqualObjects(first, first);
+    XCTAssertEqual(first.hash, first.hash);
+
+    OpenPassTokensObjC *second  = [self tokensWrapper];
+    XCTAssertEqualObjects(first, second);
+    XCTAssertEqual(first.hash, second.hash);
+}
+
+@end


### PR DESCRIPTION
Add a new package product `OpenPassObjC` containing ObjC wrappers for Swift functionality which cannot be exposed as-is. All core functionality is exposed: sign in, device auth flow, refresh token flow, accessing tokens and sign out.

In general, this package exposes functionality using `@objc` annotations in Swift code. The manager and flow code is thinly wrapped, and uses wrapped types such as `OpenPassTokensObjC` and `DeviceCodeObjC` to allow usage of existing data values in Objective-C. These wrappers compute their properties and retain the underlying values to allow for internal field usage in the core SDK.

Update CI to build and test `OpenPassObjC` for iOS and tvOS.