### PR TITLE
Simplify test-pull-request workflow

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -20,35 +20,23 @@ jobs:
       - name: Install dependencies
         run: brew install swiftlint
 
-      - name: Lint code
-        run: swiftlint lint --config .swiftlint.yml --strict --reporter github-actions-logging
-
-      - name: Select Xcode 15.3
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app
-
-      - name: Build for iOS
-        run: xcodebuild -scheme OpenPass -destination "generic/platform=iOS"
-      
-      - name: Build for tvOS
-        run: xcodebuild -scheme OpenPass -destination "generic/platform=tvOS"
-
-      - name: Build ObjC for iOS
-        run: xcodebuild -scheme OpenPassObjC -destination "generic/platform=iOS"
-      
-      - name: Build ObjC for tvOS
-        run: xcodebuild -scheme OpenPassObjC -destination "generic/platform=tvOS"
+      - name: Select Xcode 16.0
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
 
       - name: Run unit tests on iOS
-        run: xcodebuild test -scheme OpenPass -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
-
-      - name: Run unit tests on tvOS
-        run: xcodebuild test -scheme OpenPass -sdk appletvsimulator17.4 -destination "OS=17.4,name=Apple TV"
+        run: xcodebuild test -scheme OpenPass -destination "OS=18.0,name=iPhone 15"
 
       - name: Run ObjC unit tests on iOS
-        run: xcodebuild test -scheme OpenPassObjC -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15"
+        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.0,name=iPhone 15"
+
+      - name: Run unit tests on tvOS
+        run: xcodebuild test -scheme OpenPass -destination "OS=18.0,name=Apple TV"
 
       - name: Run ObjC unit tests on tvOS
-        run: xcodebuild test -scheme OpenPassObjC -sdk appletvsimulator17.4 -destination "OS=17.4,name=Apple TV"
+        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.0,name=Apple TV"
+
+      - name: Lint code
+        run: swiftlint lint --config .swiftlint.yml --strict --reporter github-actions-logging
 
       - name: Lint pod spec
         run: pod lib lint --verbose


### PR DESCRIPTION
Remove redundant build steps. Use Xcode 16. Run swiftlint after code compiles.