### PR TITLE
Fix Mailslurp inbox deletion

### DIFF
--- a/Development/OpenPassDevelopmentAppUITests/Helpers/MailSlurpClient.swift
+++ b/Development/OpenPassDevelopmentAppUITests/Helpers/MailSlurpClient.swift
@@ -62,6 +62,7 @@ final class MailSlurpClient {
     func delete(_ inbox: InboxDto) async throws {
         _ = try await InboxControllerAPI
             .deleteInboxWithRequestBuilder(inboxId: inbox._id)
+            .setApiKey(apiKey)
             .execute()
             .async()
     }


### PR DESCRIPTION
Mailslurp inbox was not being deleted after tests completed because the request was missing the API key.