### PR TITLE
Improve UI test stability

### DIFF
--- a/Development/OpenPassDevelopmentAppUITests/Helpers/TestHelpers.swift
+++ b/Development/OpenPassDevelopmentAppUITests/Helpers/TestHelpers.swift
@@ -36,14 +36,79 @@ func waitForSpringboardAlertAndContinue() {
     }
 }
 
-extension XCUIElement {
-    /// A convenience for waiting for an element to exist and then performing an action with the element.
-    @discardableResult
-    func waitForExistence(timeout: TimeInterval = webViewTimeout, action: (_ element: XCUIElement) -> Void) -> Bool {
-        if waitForExistence(timeout: timeout) {
-            action(self)
-            return true
+/// Ported to Swift from https://www.nutrient.io/blog/running-ui-tests-with-ludicrous-speed/
+/// This doesn't work for external processes, i.e. another `XCUIApplication` such as Safari.
+private func _wait(for condition: @escaping () -> Bool, timeout: CFTimeInterval = 30) -> Bool {
+    // We add a timer dispatch source here to make sure that we wake up at least every 0.x seconds
+    // in case we're waiting for a condition that does not necessarily wake up the run loop.
+    let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+    timer.schedule(wallDeadline: .now(), repeating: .milliseconds(100), leeway: .milliseconds(50))
+    timer.setEventHandler {
+        // NOOP
+    }
+    timer.resume()
+
+    var fulfilled = false
+    let flags: CFOptionFlags = CFOptionFlags(CFRunLoopActivity.beforeWaiting.rawValue)
+    let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, flags, true, 0) { _, _ in
+        fulfilled = condition()
+        if fulfilled {
+            CFRunLoopStop(CFRunLoopGetCurrent())
         }
-        return false
+    }
+    CFRunLoopAddObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
+    CFRunLoopRunInMode(.defaultMode, timeout, false)
+    CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer, .defaultMode)
+    timer.cancel()
+
+    // If we haven't fulfilled the condition yet, test one more time before returning. This avoids
+    // that we fail the test just because we somehow failed to properly poll the condition, e.g. if
+    // the run loop didn't wake up.
+    if !fulfilled {
+        fulfilled = condition()
+    }
+    return fulfilled
+}
+
+struct WaitError: Error, LocalizedError {
+    var message: String
+    var errorDescription: String? {
+        message
+    }
+}
+
+extension XCUIElement {
+    /// A convenience for waiting for the element's `exists` property to be true.
+    @discardableResult
+    func waitForExists(
+        timeout: TimeInterval = webViewTimeout,
+        action: (_ element: XCUIElement) -> Void = { _ in }
+    ) throws -> Bool {
+        try wait(for: { $0.exists }, timeout: timeout, action: action)
+    }
+
+    /// A convenience for waiting for the element's `exists`, `isHittable` and `isEnabled` properties to be true.
+    @discardableResult
+    func waitForExistsInteractive(
+        timeout: TimeInterval = webViewTimeout,
+        action: (_ element: XCUIElement) -> Void = { _ in }
+    ) throws -> Bool {
+        try wait(for: { $0.exists && $0.isHittable && $0.isEnabled }, timeout: timeout, action: action)
+    }
+
+    /// Wait for a condition to be fulfilled before performing an action with the element.
+    /// Throws an error if the condition is not met before the timeout. This is useful for async tests, where assertions do not halt the test.
+    @discardableResult
+    func wait(
+        for condition: @escaping (_ element: XCUIElement) -> Bool,
+        timeout: TimeInterval = webViewTimeout,
+        action: (_ element: XCUIElement) -> Void = { _ in }
+    ) throws -> Bool {
+        let fulfilled = _wait(for: { condition(self) }, timeout: timeout)
+        guard fulfilled else {
+            throw WaitError(message: "Condition not fulfilled for \(self.debugDescription)")
+        }
+        action(self)
+        return true
     }
 }


### PR DESCRIPTION
Use the polling approach described in this [blog](https://www.nutrient.io/blog/running-ui-tests-with-ludicrous-speed/) which allows us to check any condition, not just element exists. This allows to test that elements are hittable and enabled, for example. This should also make the tests a little faster, as the polling is more frequent than XCUITest's exists checks.

Also cause async tests to actually exit immediately by throwing an `Error` rather than using XCT Assertions.

