### PR TITLE
Add some retry handling for device test email entry

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -91,7 +91,7 @@ jobs:
           client-id: ${{ inputs.device-auth-client-id }}
           testplan: OpenPassDevelopmentAppUITests-DeviceAuth
 
-      - name: Upload and Mobile Sign-in Tests on Browserstack
+      - name: Upload and run Mobile Sign-in Tests on Browserstack
         uses: openpass-sso/shared-public-actions/actions/browserstack@v0.0.1
         with:
           browserstackUsername: ${{ secrets.BROWSERSTACK_USERNAME }}


### PR DESCRIPTION
Tests most frequently fail when testing the existence of elements in the first webview load. Retrying these checks appears  to result in more frequent success. For sign-in, add an additional check for the email address input field. For the Device Auth test, add an additional check for the initial button which accepts device registration.

Also reduce general element existence timeout to 15 seconds.