### PR TITLE
Add support for SDK name suffix

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -4,9 +4,9 @@ Releases are performed via [GitHub Releases](https://docs.github.com/en/reposito
 
 ### Steps
 
-1. Confirm `sdkVersion` in `OpenPassManager` is expected version.
+1. Confirm `sdkVersion` in `OpenPassConfiguration.swift` is expected version.
 2. Use GitHub Releases to create tag matching `sdkVersion` in `OpenPassManager` and publish release.
-3. Update `sdkVersion` in `OpenPassManager` to next minor version to support future development and merge into `main`.
+3. Update `sdkVersion` in `OpenPassConfiguration.swift` to next minor version to support future development and merge into `main`.
 
 ### CocoaPods
 

--- a/Sources/OpenPass/Extensions/String+Extensions.swift
+++ b/Sources/OpenPass/Extensions/String+Extensions.swift
@@ -64,5 +64,13 @@ extension String {
         return try? JSONSerialization.jsonObject(with: componentData, options: []) as? [String: Any]
         
     }
-    
+
+    internal func trimmingTrailing(_ suffix: String) -> String {
+        if hasSuffix(suffix) {
+            String(dropLast(suffix.count))
+        } else {
+            self
+        }
+    }
+
 }

--- a/Sources/OpenPass/OpenPassClient.swift
+++ b/Sources/OpenPass/OpenPassClient.swift
@@ -31,14 +31,33 @@ import Foundation
 @available(iOS 13.0, tvOS 16.0, *)
 internal final class OpenPassClient {
     
+    /// OpenPass Server URL for Web UX and API Server
+    /// Override default by setting `OpenPassBaseURL` in app's Info.plist
     private let baseURL: String
-    private let baseRequestParameters: BaseRequestParameters
+
+    /// Keys and Values that need to be included in every network request
+    let baseRequestParameters: BaseRequestParameters
+
     let clientId: String
     private let session = URLSession.shared
 
-    init(baseURL: String, baseRequestParameters: BaseRequestParameters, clientId: String) {
+    convenience init(configuration: OpenPassConfiguration) {
+        self.init(
+            baseURL: configuration.baseURL,
+            sdkName: configuration.sdkName,
+            sdkVersion: configuration.sdkVersion,
+            clientId: configuration.clientId
+        )
+    }
+
+    init(
+        baseURL: String,
+        sdkName: String,
+        sdkVersion: String = openPassSdkVersion,
+        clientId: String
+    ) {
         self.baseURL = baseURL
-        self.baseRequestParameters = baseRequestParameters
+        self.baseRequestParameters = BaseRequestParameters(sdkName: sdkName, sdkVersion: sdkVersion)
         self.clientId = clientId
     }
 

--- a/Sources/OpenPass/OpenPassSettings.swift
+++ b/Sources/OpenPass/OpenPassSettings.swift
@@ -74,6 +74,23 @@ public final class OpenPassSettings: NSObject, @unchecked Sendable {
         }
     }
 
+    private var _sdkNameSuffix: String?
+
+    /// OpenPass SDK Name suffix. The default value is `nil`.
+    @objc
+    public var sdkNameSuffix: String? {
+        get {
+            queue.sync {
+                _sdkNameSuffix
+            }
+        }
+        set {
+            queue.sync {
+                _sdkNameSuffix = newValue
+            }
+        }
+    }
+
     @objc
     public static let shared = OpenPassSettings()
 }

--- a/Tests/OpenPassTests/OpenPassClientTests.swift
+++ b/Tests/OpenPassTests/OpenPassClientTests.swift
@@ -30,7 +30,52 @@ import XCTest
 
 @available(iOS 13.0, *)
 final class OpenPassClientTests: XCTestCase {
-    
+
+    func testBaseRequestParameters() async throws {
+        let client = OpenPassClient(
+            configuration: .init(
+                clientId: "id",
+                redirectHost: "host",
+                sdkVersion: "1.0.0"
+            )
+        )
+        XCTAssertEqual(
+            client.baseRequestParameters,
+            .init(
+                sdkName: "openpass-ios-sdk",
+                sdkVersion: "1.0.0"
+            )
+        )
+    }
+
+    func testBaseRequestParametersWithSdkNameSuffix() async throws {
+        let client = OpenPassClient(
+            configuration: .init(
+                clientId: "id",
+                redirectHost: "host",
+                sdkNameSuffix: "-testSuffix",
+                sdkVersion: "0.a.1"
+            )
+        )
+        XCTAssertEqual(
+            client.baseRequestParameters,
+            .init(
+                sdkName: "openpass-ios-sdk-testSuffix",
+                sdkVersion: "0.a.1"
+            )
+        )
+    }
+
+    func testBaseRequestParametersWithSdkNameSuffixFromSettings() async throws {
+        OpenPassSettings.shared.sdkNameSuffix = "-settings-suffix"
+        let client = OpenPassClient(
+            configuration: .init()
+        )
+        OpenPassSettings.shared.sdkNameSuffix = nil
+        let sdkName = try XCTUnwrap(client.baseRequestParameters.asHeaderPairs["SDK-Name"])
+        XCTAssertEqual(sdkName, "openpass-ios-sdk-settings-suffix")
+    }
+
     /// 🟩  `POST /v1/api/token` - HTTP 200
     func testGetTokenFromAuthCodeSuccess() async throws {
         try HTTPStub.shared.stubAlways(fixture: "openpasstokens-200")

--- a/Tests/OpenPassTests/TestExtensions/OpenPassClient+TestExtensions.swift
+++ b/Tests/OpenPassTests/TestExtensions/OpenPassClient+TestExtensions.swift
@@ -30,10 +30,7 @@
 extension OpenPassClient {
     static let test = OpenPassClient(
         baseURL: "https://auth.myopenpass.com/",
-        baseRequestParameters: BaseRequestParameters(
-            sdkName: "OpenPassTest",
-            sdkVersion: "TEST"
-        ),
+        sdkName: "OpenPassTest",
         clientId: "test-client"
     )
 }


### PR DESCRIPTION
We want to suffix the SDK-Name HTTP header/query parameter when the SDK is wrapped/embedded in another SDK.

Add new public API property to `OpenPassSettings` to allow setting an SDK name suffix.

I also took the opportunity to move some of the private Client configuration/properties out of `OpenPassManager` to `OpenPassClient`.
