### PR TITLE
Add Environment support to OpenPassSettings

### DIFF
--- a/Sources/OpenPass/Environment.swift
+++ b/Sources/OpenPass/Environment.swift
@@ -1,0 +1,44 @@
+//
+//  Environment.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+public struct Environment: Hashable, Sendable {
+
+    /// API base URL
+    var endpoint: URL
+
+    /// The default Environment used in Production.
+    public static let production = Self(endpoint: URL(string: "https://auth.myopenpass.com/")!)
+
+    /// A Staging Environment for internal development.
+    public static let staging = Self(endpoint: URL(string: "https://auth.stg.myopenpass.com/")!)
+
+    /// A custom endpoint
+    public static func custom(url: URL) -> Self {
+        Self(endpoint: url)
+    }
+}

--- a/Sources/OpenPass/OpenPassClient.swift
+++ b/Sources/OpenPass/OpenPassClient.swift
@@ -124,12 +124,10 @@ internal final class OpenPassClient {
 
     // MARK: - Request Execution
 
-    private func urlRequest<ResponseType>(
-        _ request: Request<ResponseType>,
-        baseURL: URL,
-        httpHeaders: [String: String] = [:]
+    internal func urlRequest<ResponseType>(
+        _ request: Request<ResponseType>
     ) -> URLRequest {
-        var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)!
+        var urlComponents = URLComponents(url: URL(string: baseURL)!, resolvingAgainstBaseURL: true)!
         urlComponents.path = request.path
 
         var urlRequest = URLRequest(url: urlComponents.url!)
@@ -141,7 +139,7 @@ internal final class OpenPassClient {
             urlRequest.httpBody = encodedPostBody(request.queryItems)
         }
 
-        httpHeaders.forEach { field, value in
+        baseRequestParameters.asHeaderPairs.forEach { field, value in
             urlRequest.addValue(value, forHTTPHeaderField: field)
         }
         return urlRequest
@@ -156,9 +154,7 @@ internal final class OpenPassClient {
 
     private func execute<ResponseType: Decodable>(_ request: Request<ResponseType>) async throws -> ResponseType {
         let urlRequest = urlRequest(
-            request,
-            baseURL: URL(string: baseURL)!,
-            httpHeaders: baseRequestParameters.asHeaderPairs
+            request
         )
         let data = try await session.data(for: urlRequest).0
         let decoder = JSONDecoder()

--- a/Sources/OpenPass/OpenPassConfiguration.swift
+++ b/Sources/OpenPass/OpenPassConfiguration.swift
@@ -59,6 +59,8 @@ struct OpenPassConfiguration: Hashable, Sendable {
             baseURL: {
                 if let baseURLOverride = Bundle.main.object(forInfoDictionaryKey: "OpenPassBaseURL") as? String, !baseURLOverride.isEmpty {
                     baseURLOverride
+                } else if let environment = OpenPassSettings.shared.environment {
+                    environment.endpoint.absoluteString
                 } else {
                     Self.defaultBaseURL
                 }

--- a/Sources/OpenPass/OpenPassSettings.swift
+++ b/Sources/OpenPass/OpenPassSettings.swift
@@ -74,6 +74,24 @@ public final class OpenPassSettings: NSObject, @unchecked Sendable {
         }
     }
 
+    private var _environment: Environment?
+
+    /// OpenPass API Environment. The default value is `nil`, which result in Production being used.
+    /// Setting a value of `Environment.custom` is equivalent to providing a value for `OpenPassBaseURL` in your Info.plist,
+    /// however any value in the Info.plist will override this setting.
+    public var environment: Environment? {
+        get {
+            queue.sync {
+                _environment
+            }
+        }
+        set {
+            queue.sync {
+                _environment = newValue
+            }
+        }
+    }
+
     private var _sdkNameSuffix: String?
 
     /// OpenPass SDK Name suffix. The default value is `nil`.

--- a/Sources/OpenPassObjC/OpenPassEnvironmentObjC.swift
+++ b/Sources/OpenPassObjC/OpenPassEnvironmentObjC.swift
@@ -1,0 +1,52 @@
+//
+//  OpenPassEnvironmentObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+/// Wraps the `Environment` struct, which cannot be exposed to Objective-C.
+@objc
+public final class OpenPassEnvironmentObjC: NSObject, @unchecked Sendable {
+    var environment: Environment
+
+    init(_ environment: Environment) {
+        self.environment = environment
+    }
+
+    /// The default Environment used in Production.
+    @objc
+    public static let production = OpenPassEnvironmentObjC(.production)
+
+    /// A Staging Environment for internal development.
+    @objc
+    public static let staging = OpenPassEnvironmentObjC(.staging)
+
+    /// A custom endpoint
+    @objc
+    public static func custom(url: URL) -> OpenPassEnvironmentObjC {
+        OpenPassEnvironmentObjC(.custom(url: url))
+    }
+}

--- a/Sources/OpenPassObjC/OpenPassSettingsObjC.swift
+++ b/Sources/OpenPassObjC/OpenPassSettingsObjC.swift
@@ -1,0 +1,63 @@
+//
+//  OpenPassSettingsObjC.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import OpenPass
+
+extension OpenPassSettings {
+
+    /// OpenPass API Environment. The default value is `nil`, which result in Production being used.
+    /// Setting a value of `Environment.custom` is equivalent to providing a value for `OpenPassBaseURL` in your Info.plist,
+    /// however any value in the Info.plist will override this setting.
+    @objc
+    public var environmentObjC: OpenPassEnvironmentObjC? {
+        get {
+            environment.map(OpenPassEnvironmentObjC.init)
+        }
+        set {
+            environment = newValue?.environment
+        }
+    }
+}
+
+// MARK: - Equatable
+
+extension OpenPassEnvironmentObjC {
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return environment == other.environment
+    }
+}
+
+// MARK: - Hashable
+
+extension OpenPassEnvironmentObjC {
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(environment)
+        return hasher.finalize()
+    }
+}

--- a/Tests/OpenPassObjCTests/OpenPassEnvironmentObjCTests.m
+++ b/Tests/OpenPassObjCTests/OpenPassEnvironmentObjCTests.m
@@ -1,0 +1,84 @@
+//
+//  OpenPassManagerObjCTests.m
+//
+// MIT License
+//
+// Copyright (c) 2024 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@import OpenPass;
+@import OpenPassObjC;
+@import ObjCTestHelpers;
+@import XCTest;
+
+@interface OpenPassEnvironmentObjCTests : XCTestCase
+
+@end
+
+@implementation OpenPassEnvironmentObjCTests
+
+- (void)testSettings
+{
+    XCTAssertNil(OpenPassSettings.shared.environmentObjC);
+
+    OpenPassSettings.shared.environmentObjC = [OpenPassEnvironmentObjC production];
+    XCTAssertEqualObjects(OpenPassSettings.shared.environmentObjC, [OpenPassEnvironmentObjC production]);
+
+    OpenPassSettings.shared.environmentObjC = nil;
+    XCTAssertNil(OpenPassSettings.shared.environmentObjC);
+}
+
+- (void)testEquatable
+{
+    OpenPassEnvironmentObjC *production = [OpenPassEnvironmentObjC production];
+    XCTAssertTrue([production isEqual:production]);
+    XCTAssertTrue([[OpenPassEnvironmentObjC production] isEqual:[OpenPassEnvironmentObjC production]]);
+    XCTAssertTrue([[OpenPassEnvironmentObjC production] isEqual:[OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://auth.myopenpass.com/"]]]);
+
+    OpenPassEnvironmentObjC *staging = [OpenPassEnvironmentObjC staging];
+    XCTAssertTrue([staging isEqual:staging]);
+    XCTAssertTrue([[OpenPassEnvironmentObjC staging] isEqual:[OpenPassEnvironmentObjC staging]]);
+    XCTAssertTrue([[OpenPassEnvironmentObjC staging] isEqual:[OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://auth.stg.myopenpass.com/"]]]);
+
+    OpenPassEnvironmentObjC *custom = [OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://auth.myopenpass.com/"]];
+    XCTAssertTrue([custom isEqual:custom]);
+    XCTAssertTrue([[OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://auth.myopenpass.com/"]] isEqual:[OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://auth.myopenpass.com/"]]]);
+
+    XCTAssertFalse([[OpenPassEnvironmentObjC production] isEqual:[OpenPassEnvironmentObjC staging]]);
+    XCTAssertFalse([[OpenPassEnvironmentObjC production] isEqual:[OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://example.com/"]]]);
+}
+
+- (void)testHashable
+{
+    OpenPassEnvironmentObjC *production = [OpenPassEnvironmentObjC production];
+    XCTAssertEqualObjects(production, production);
+    XCTAssertEqual(production.hash, production.hash);
+
+    OpenPassEnvironmentObjC *staging = [OpenPassEnvironmentObjC staging];
+    XCTAssertEqualObjects(staging, staging);
+    XCTAssertEqual(staging.hash, staging.hash);
+
+    OpenPassEnvironmentObjC *custom = [OpenPassEnvironmentObjC customWithUrl:[NSURL URLWithString:@"https://example.com/"]];
+    XCTAssertEqualObjects(custom, custom);
+    XCTAssertEqual(custom.hash, custom.hash);
+}
+
+@end

--- a/Tests/OpenPassTests/OpenPassClientTests.swift
+++ b/Tests/OpenPassTests/OpenPassClientTests.swift
@@ -76,6 +76,16 @@ final class OpenPassClientTests: XCTestCase {
         XCTAssertEqual(sdkName, "openpass-ios-sdk-settings-suffix")
     }
 
+    func testBaseURLFromConfiguration() async throws {
+        OpenPassSettings.shared.environment = .custom(url: URL(string: "https://tests.example.com/")!)
+        let client = OpenPassClient(
+            configuration: .init()
+        )
+        OpenPassSettings.shared.environment = nil
+        let request = client.urlRequest(Request<Void>(path: "/test"))
+        XCTAssertEqual(request.url?.absoluteString, "https://tests.example.com/test")
+    }
+
     /// 🟩  `POST /v1/api/token` - HTTP 200
     func testGetTokenFromAuthCodeSuccess() async throws {
         try HTTPStub.shared.stubAlways(fixture: "openpasstokens-200")

--- a/Tests/OpenPassTests/OpenPassConfigurationTests.swift
+++ b/Tests/OpenPassTests/OpenPassConfigurationTests.swift
@@ -1,0 +1,122 @@
+//
+//  OpenPassClientTests.swift
+//  
+//
+// MIT License
+//
+// Copyright (c) 2022 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+@testable import OpenPass
+import XCTest
+
+@available(iOS 13.0, *)
+final class OpenPassConfigurationTests: XCTestCase {
+
+    func testBaseURL() async throws {
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.baseURL, "https://auth.myopenpass.com/")
+        }
+
+        // override
+        do {
+            OpenPassSettings.shared.environment = .custom(url: URL(string: "https://tests.example.com/")!)
+            let configuration = OpenPassConfiguration()
+            OpenPassSettings.shared.environment = nil
+            XCTAssertEqual(configuration.baseURL, "https://tests.example.com/")
+        }
+
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.baseURL, "https://auth.myopenpass.com/")
+        }
+    }
+
+    func testClientId() async throws {
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.clientId, "")
+        }
+
+        // override
+        do {
+            OpenPassSettings.shared.clientId = "12345"
+            let configuration = OpenPassConfiguration()
+            OpenPassSettings.shared.clientId = nil
+            XCTAssertEqual(configuration.clientId, "12345")
+        }
+
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.clientId, "")
+        }
+    }
+
+    func testRedirectHost() async throws {
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.redirectHost, "")
+        }
+
+        // override
+        do {
+            OpenPassSettings.shared.redirectHost = "https://tests.example.com/"
+            let configuration = OpenPassConfiguration()
+            OpenPassSettings.shared.redirectHost = nil
+            XCTAssertEqual(configuration.redirectHost, "https://tests.example.com/")
+        }
+
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.redirectHost, "")
+        }
+    }
+
+    func testSdkNameSuffix() async throws {
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.sdkName, "openpass-ios-sdk")
+        }
+
+        // override
+        do {
+            OpenPassSettings.shared.sdkNameSuffix = "-suffix"
+            let configuration = OpenPassConfiguration()
+            OpenPassSettings.shared.sdkNameSuffix = nil
+            XCTAssertEqual(configuration.sdkName, "openpass-ios-sdk-suffix")
+        }
+
+        // default
+        do {
+            let configuration = OpenPassConfiguration()
+            XCTAssertEqual(configuration.sdkName, "openpass-ios-sdk")
+        }
+    }
+
+}


### PR DESCRIPTION
Add `Environment` support to `OpenPassSettings`, allowing named and custom API endpoints to be set from Swift and Objective-C interfaces. This is a required change for Unity, where customisation of the `Info.plist` is cumbersome.