### PR TITLE
Don't lint OpenPassObjC podspec during PR tests

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -3,10 +3,16 @@ name: cocoapods-publish
 on:
   workflow_dispatch:
     inputs:
-        version:
-          description: 'Tag name for release (e.g. "1.0.0")'
-          required: true
-          type: string
+      name:
+        type: choice
+        description: CocoaPod to Publish
+        options: 
+        - OpenPass
+        - OpenPassObjC
+      version:
+        description: 'Tag name for release (e.g. "1.0.0")'
+        required: true
+        type: string
 
 # https://github.com/actions/runner-images/?tab=readme-ov-file#available-images
 jobs:
@@ -19,22 +25,19 @@ jobs:
     - name: Set up
       run: mkdir tmp
 
-    - name: Update podspecs
+    - name: Update podspec
       run: |
-        jq --arg VERSION "${{ inputs.version }}" '. | .version |= $VERSION | .source.tag |= $VERSION' OpenPass.podspec.json > tmp/OpenPass.podspec.json
-        jq --arg VERSION "${{ inputs.version }}" '. | .version |= $VERSION | .source.tag |= $VERSION' OpenPassObjC.podspec.json > tmp/OpenPassObjC.podspec.json
-
-    - name: Lint podspecs
+        jq --arg VERSION "${{ inputs.version }}" '. | .version |= $VERSION | .source.tag |= $VERSION' ${{ github.event.inputs.name }}.podspec.json > tmp/${{ github.event.inputs.name }}.podspec.json
+        
+    - name: Lint podspec
       run: |
-        pod spec lint tmp/OpenPass.podspec.json
-        pod spec lint tmp/OpenPassObjC.podspec.json
+        pod spec lint tmp/${{ github.event.inputs.name }}.podspec.json
 
-    - name: Push podspecs to Cocoapods trunk
+    - name: Push podspec to Cocoapods trunk
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: |
-        pod trunk push tmp/OpenPass.podspec.json
-        pod trunk push tmp/OpenPassObjC.podspec.json
+        pod trunk push tmp/${{ github.event.inputs.name }}.podspec.json
 
     - name: Clean up
       run: rm -r tmp

--- a/.github/workflows/lint-objc-podspec.yml
+++ b/.github/workflows/lint-objc-podspec.yml
@@ -1,0 +1,24 @@
+name: Lint Pull Requests for OpenPassObjC
+
+on:
+  pull_request:
+    paths:
+      - OpenPassObjC.podspec.json
+
+  # this allows us to manually run this job
+  workflow_dispatch:
+
+jobs:
+
+  lint-podspec:
+    name: Lint OpenPassObjC Podspec
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.1
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app
+
+      - name: Lint OpenPass podspec
+        run: pod lib lint OpenPassObjC.podspec.json --verbose

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Lint OpenPass podspec
         run: pod lib lint OpenPass.podspec.json --verbose
 
-      - name: Lint OpenPassObjC podspec
-        run: pod lib lint OpenPassObjC.podspec.json --verbose
-
   device-tests:
     uses: ./.github/workflows/device-tests.yml
     with: 


### PR DESCRIPTION
#66 is failing checks because the pod lint step for the OpenPassObjC wrapper can only run against the latest production release of its dependency `OpenPass`, which also has changes. There's no way around this using CocoaPods – a release to the dependency has to be made before lint will pass for a new release of the dependent library. 

Remove the lint step from the PR tests, adding a new PR job that runs if the podspec itself is modified. The lint was a nice to have, but the library is still compiled during PR checks, and the pod is unlikely to change.

Decouple the release job, `cocoapods-publish.yml`, which also performs linting, so that the `OpenPass` pod can be published before the `OpenPassObjC` pod.

[Sample workflow run for the updated cocoapods-publish using existing version 1.2.0](https://github.com/openpass-sso/openpass-ios-sdk/actions/runs/13137730903/job/36657038648) (fails for duplicate pod, as expected).