### PR TITLE
Bump CI Xcode to 16.2, iOS 18.2 for tests

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Install dependencies
         run: brew install swiftlint
 
-      - name: Select Xcode 16.1
+      - name: Select Xcode 16.2
         run: sudo xcode-select -s /Applications/Xcode_16.1.app
 
       - name: Run unit tests on iOS
-        run: xcodebuild test -scheme OpenPass -destination "OS=18.1,name=iPhone 15"
+        run: xcodebuild test -scheme OpenPass -destination "OS=18.2,name=iPhone 16"
 
       - name: Run ObjC unit tests on iOS
-        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.1,name=iPhone 15"
+        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.2,name=iPhone 16"
 
       - name: Run unit tests on tvOS
-        run: xcodebuild test -scheme OpenPass -destination "OS=18.1,name=Apple TV"
+        run: xcodebuild test -scheme OpenPass -destination "OS=18.2,name=Apple TV"
 
       - name: Run ObjC unit tests on tvOS
-        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.1,name=Apple TV"
+        run: xcodebuild test -scheme OpenPassObjC -destination "OS=18.2,name=Apple TV"
 
       - name: Lint code
         run: swiftlint lint --config .swiftlint.yml --strict --reporter github-actions-logging


### PR DESCRIPTION
This [run](https://github.com/openpass-sso/openpass-ios-sdk/actions/runs/13765753298/job/38491694143?pr=69) failed because the GitHub worker image no longer contains an iPhone 15 simulator. Upgrade Xcode and use a newer simulator. 