### PR TITLE
Use Stream to observe token changes in dev-app

### DIFF
--- a/Development/OpenPassDevelopmentApp.xcodeproj/project.pbxproj
+++ b/Development/OpenPassDevelopmentApp.xcodeproj/project.pbxproj
@@ -497,7 +497,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -531,7 +531,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Development/OpenPassDevelopmentApp/DeviceAuthorizationView.swift
+++ b/Development/OpenPassDevelopmentApp/DeviceAuthorizationView.swift
@@ -29,7 +29,7 @@ import SwiftUI
 
 struct DeviceAuthorizationView: View {
     
-    @ObservedObject
+    @StateObject
     private var viewModel = DeviceAuthorizationViewModel()
 
     @Binding var showDeviceAuthorizationView: Bool

--- a/Development/OpenPassDevelopmentApp/Localizable.strings
+++ b/Development/OpenPassDevelopmentApp/Localizable.strings
@@ -31,7 +31,7 @@
 "root.label.openpassTokens.idToken" = "ID Token";
 "root.label.openpassTokens.accessToken" = "Access Token";
 "root.label.openpassTokens.tokenType" = "Token Type";
-"root.label.openpassTokens.expiresIn" = "Expires In";
+"root.label.openpassTokens.expiresAt" = "Expires At";
 "root.label.openpassTokens.refreshToken" = "Refresh Token";
 "root.label.openpassTokens.email" = "Email Claim";
 "root.label.openpassTokens.givenName" = "Given Name Claim";

--- a/Development/OpenPassDevelopmentApp/OpenPassTokensView.swift
+++ b/Development/OpenPassDevelopmentApp/OpenPassTokensView.swift
@@ -66,10 +66,10 @@ struct OpenPassTokensView: View {
                 .font(Font.system(size: 16, weight: .regular))
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(LocalizedStringKey("root.label.openpassTokens.expiresIn"))
+            Text(LocalizedStringKey("root.label.openpassTokens.expiresAt"))
                 .font(Font.system(size: 18, weight: .bold))
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text(viewModel.expiresIn)
+            Text(viewModel.expiresAt)
                 .font(Font.system(size: 16, weight: .regular))
                 .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/Development/OpenPassDevelopmentApp/RootView.swift
+++ b/Development/OpenPassDevelopmentApp/RootView.swift
@@ -81,6 +81,12 @@ struct RootView: View {
         .sheet(isPresented: $viewModel.showDAF, content: {
             DeviceAuthorizationView(showDeviceAuthorizationView: $viewModel.showDAF)
         })
+        .onAppear {
+            viewModel.startObservingTokens()
+        }
+        .onDisappear {
+            viewModel.stopObservingTokens()
+        }
     }
 }
 extension View {


### PR DESCRIPTION
Update dev-app to observe the stream of token values, rather than updating state imperatively.

Fix `ObservedObject` usage in `DeviceAuthorizationView` which caused duplicate view models to be created. `StateObject` should be used as the owner of the value. This requires an iOS deployment target bump to 14.0.