### PR TITLE
Add Telemetry Events

### DIFF
--- a/Sources/OpenPass/Data/TelemetryEvent.swift
+++ b/Sources/OpenPass/Data/TelemetryEvent.swift
@@ -1,0 +1,71 @@
+//
+//  TelemetryEvent.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+
+private let stackTraceMaxSize = 10_000
+
+struct TelemetryEvent: Encodable {
+    var clientId: String
+    var name: String
+    var message: String
+    var eventType: EventType
+
+    enum EventType {
+        case info
+        case error(stackTrace: String?)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case clientId
+        case name
+        case message
+        case eventType
+        case stackTrace
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(clientId, forKey: .clientId)
+        try container.encode(name, forKey: .name)
+        try container.encode(message, forKey: .message)
+        switch eventType {
+        case .info:
+            try container.encode("info", forKey: .eventType)
+        case .error(let stackTrace):
+            try container.encode("error", forKey: .eventType)
+            if let stackTrace {
+                try container.encode(String(stackTrace.prefix(stackTraceMaxSize)), forKey: .stackTrace)
+            }
+        }
+    }
+}
+
+extension Thread {
+    static var formattedCallStackSymbols: String {
+        callStackSymbols.joined(separator: "\n")
+    }
+}

--- a/Sources/OpenPass/Request.swift
+++ b/Sources/OpenPass/Request.swift
@@ -31,20 +31,41 @@ enum Method: String {
     case post = "POST"
 }
 
+enum RequestBody {
+    case none
+    case form([URLQueryItem])
+    case json(Encodable)
+}
+
 struct Request<ResponseType> {
     var method: Method
     var path: String
-    var queryItems: [URLQueryItem]
-    var body: Data?
+    var body: RequestBody
 
-    init(path: String, method: Method = .get, queryItems: [URLQueryItem] = [], body: Data? = nil) {
+    init(
+        path: String,
+        method: Method = .get,
+        body: RequestBody = .none
+    ) {
         self.path = path
         self.method = method
-        self.queryItems = queryItems
         self.body = body
     }
 }
 
+// MARK: - Telemetry
+
+extension Request where ResponseType == Void {
+    static func telemetryEvent(
+        _ event: TelemetryEvent
+    ) -> Request {
+        .init(
+            path: "/v1/api/telemetry/sdk_event",
+            method: .post,
+            body: .json(event)
+        )
+    }
+}
 // MARK: - Tokens
 
 extension Request where ResponseType == OpenPassTokensResponse {
@@ -57,13 +78,13 @@ extension Request where ResponseType == OpenPassTokensResponse {
         .init(
             path: "/v1/api/token",
             method: .post,
-            queryItems: [
+            body: .form([
                 .init(name: "client_id", value: clientId),
                 .init(name: "code_verifier", value: codeVerifier),
                 .init(name: "code", value: code),
                 .init(name: "grant_type", value: "authorization_code"),
                 .init(name: "redirect_uri", value: redirectUri)
-            ]
+            ])
         )
     }
 
@@ -74,11 +95,11 @@ extension Request where ResponseType == OpenPassTokensResponse {
         .init(
             path: "/v1/api/token",
             method: .post,
-            queryItems: [
+            body: .form([
                 .init(name: "client_id", value: clientId),
                 .init(name: "grant_type", value: "refresh_token"),
                 .init(name: "refresh_token", value: refreshToken)
-            ]
+            ])
         )
     }
 }
@@ -90,10 +111,10 @@ extension Request where ResponseType == DeviceAuthorizationResponse {
         .init(
             path: "/v1/api/authorize-device",
             method: .post,
-            queryItems: [
+            body: .form([
                 URLQueryItem(name: "client_id", value: clientId),
                 URLQueryItem(name: "scope", value: "openid")
-            ]
+            ])
         )
     }
 }
@@ -106,11 +127,11 @@ extension Request where ResponseType == OpenPassTokensResponse {
         .init(
             path: "/v1/api/device-token",
             method: .post,
-            queryItems: [
+            body: .form([
                 URLQueryItem(name: "client_id", value: clientId),
                 URLQueryItem(name: "device_code", value: deviceCode),
                 URLQueryItem(name: "grant_type", value: "urn:ietf:params:oauth:grant-type:device_code")
-            ]
+            ])
         )
     }
 }

--- a/Tests/OpenPassTests/RequestTests.swift
+++ b/Tests/OpenPassTests/RequestTests.swift
@@ -127,4 +127,65 @@ final class RequestTests: XCTestCase {
             """
         }
     }
+
+    func testEventTelemetryInfo() {
+        let request = Request.telemetryEvent(
+            .init(
+                clientId: "client-id-13",
+                name: "An event",
+                message: "of telemetry",
+                eventType: .info
+            )
+        )
+        assertInlineSnapshot(of: client.urlRequest(request), as: .raw(pretty: true)) {
+            """
+            POST https://auth.myopenpass.com/v1/api/telemetry/sdk_event
+            Content-Type: application/json
+            Device-Manufacturer: Apple
+            Device-Model: iPhone
+            Device-Platform-Version: 18.0
+            Device-Platform: iOS
+            SDK-Name: openpass-ios-sdk
+            SDK-Version: 1.0.0
+
+            {
+              "client_id" : "client-id-13",
+              "event_type" : "info",
+              "message" : "of telemetry",
+              "name" : "An event"
+            }
+            """
+        }
+    }
+
+    func testEventTelemetryError() {
+        let request = Request.telemetryEvent(
+            .init(
+                clientId: "client-id-13",
+                name: "An event",
+                message: "of telemetry",
+                eventType: .error(stackTrace: "something\nhappened\n")
+            )
+        )
+        assertInlineSnapshot(of: client.urlRequest(request), as: .raw(pretty: true)) {
+            #"""
+            POST https://auth.myopenpass.com/v1/api/telemetry/sdk_event
+            Content-Type: application/json
+            Device-Manufacturer: Apple
+            Device-Model: iPhone
+            Device-Platform-Version: 18.0
+            Device-Platform: iOS
+            SDK-Name: openpass-ios-sdk
+            SDK-Version: 1.0.0
+
+            {
+              "client_id" : "client-id-13",
+              "event_type" : "error",
+              "message" : "of telemetry",
+              "name" : "An event",
+              "stack_trace" : "something\nhappened\n"
+            }
+            """#
+        }
+    }
 }

--- a/Tests/OpenPassTests/TelemetryEventTests.swift
+++ b/Tests/OpenPassTests/TelemetryEventTests.swift
@@ -1,0 +1,91 @@
+//
+//  TelemetryEventTests.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+import InlineSnapshotTesting
+@testable import OpenPass
+import XCTest
+
+final class TelemetryEventTests: XCTestCase {
+    
+    func testEventTelemetryInfo() {
+        let event = TelemetryEvent(
+            clientId: "client-id-13",
+            name: "An event",
+            message: "of telemetry",
+            eventType: .info
+        )
+        assertInlineSnapshot(of: event, as: .requestJson) {
+            """
+            {
+              "client_id" : "client-id-13",
+              "event_type" : "info",
+              "message" : "of telemetry",
+              "name" : "An event"
+            }
+            """
+        }
+    }
+    
+    func testEventTelemetryError() {
+        let event = TelemetryEvent(
+            clientId: "client-id-13",
+            name: "An event",
+            message: "of telemetry",
+            eventType: .error(stackTrace: nil)
+        )
+        assertInlineSnapshot(of: event, as: .requestJson) {
+            """
+            {
+              "client_id" : "client-id-13",
+              "event_type" : "error",
+              "message" : "of telemetry",
+              "name" : "An event"
+            }
+            """
+        }
+    }
+    
+    func testEventTelemetryErrorStackTrace() {
+        let event = TelemetryEvent(
+            clientId: "client-id-13",
+            name: "An event",
+            message: "of telemetry",
+            eventType: .error(stackTrace: "something\nhappened\n")
+        )
+        assertInlineSnapshot(of: event, as: .requestJson) {
+            #"""
+            {
+              "client_id" : "client-id-13",
+              "event_type" : "error",
+              "message" : "of telemetry",
+              "name" : "An event",
+              "stack_trace" : "something\nhappened\n"
+            }
+            """#
+        }
+    }
+}

--- a/Tests/OpenPassTests/TestExtensions/Snapshotting.swift
+++ b/Tests/OpenPassTests/TestExtensions/Snapshotting.swift
@@ -1,0 +1,38 @@
+//
+//  Snapshotting.swift
+//
+// MIT License
+//
+// Copyright (c) 2025 The Trade Desk (https://www.thetradedesk.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import Foundation
+@testable import OpenPass
+import SnapshotTesting
+
+extension Snapshotting where Value: Encodable, Format == String {
+    @available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)
+    public static var requestJson: Snapshotting {
+        let encoder = OpenPassClient.encoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return .json(encoder)
+    }
+}


### PR DESCRIPTION
Add support for recording telemetry events, and add those from Android which are applicable here (some are Android lifecycle-related).

Modifies internal `Request` type to explicitly structure the request body as either form encoded key/value pairs, or an encodable JSON value. Existing Request tests are passing unmodified.