### PR TITLE
Set run-name for CocoaPods publish workflow

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -14,6 +14,8 @@ on:
         required: true
         type: string
 
+run-name: "Publish CocoaPod ${{ inputs.name }} version ${{ inputs.version }}"
+
 # https://github.com/actions/runner-images/?tab=readme-ov-file#available-images
 jobs:
   publish:


### PR DESCRIPTION
Set a run name to appear in the [Actions run list ](https://github.com/openpass-sso/openpass-ios-sdk/actions/workflows/cocoapods-publish.yml)