### PR TITLE
Support consent and passkey screens

### DIFF
--- a/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
+++ b/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
@@ -185,6 +185,14 @@ final class OpenPassDevelopmentAppUITests: XCTestCase {
         try signInView.codeInput.waitForExistence { _ in
             signInView.enterCode(code)
         }
+
+        try signInView.consentAgreeButton.waitForExistence {
+            $0.tap()
+        }
+
+        try signInView.passKeysSkipButton.waitForExistence {
+            $0.tap()
+        }
     }
 }
 
@@ -219,6 +227,14 @@ final class SignInView {
     /// OTP Code Input suitable for testing existence
     var codeInput: XCUIElement {
         codeInput(for: 5)
+    }
+
+    var consentAgreeButton: XCUIElement {
+        rootElement.buttons["Agree and continue"]
+    }
+
+    var passKeysSkipButton: XCUIElement {
+        rootElement.buttons["No thanks"]
     }
 
     func enterCode(_ code: String) {


### PR DESCRIPTION
<!--
## Note to author:
* Please fill in this template fully for every PR.
* For FE features, it is a requirement to include screenshots and/or videos of the feature working. Videos are preferred. However, all changes will benefit from screenshots of testing evidence.
* Ensure the size and complexity of your PR is as small as possible. This will help the reviewer give a good review.
* Choose your reviewer wisely - they should be SMEs in the area of change. Multiple reviewers for complex changes are encouraged.
-->
## Note to reviewer:
* The reviewer is responsible for the functionality of this PR working correctly just as much as the author. It is encouraged for the reviewer to check out the change and test according to the test plan.

## What does this PR solve?

Supports tapping through the consent and passkey configuration screens during device tests.