### PR TITLE
Update passkeys skip button test label

### DIFF
--- a/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
+++ b/Development/OpenPassDevelopmentAppUITests/OpenPassDevelopmentAppUITests.swift
@@ -234,7 +234,7 @@ final class SignInView {
     }
 
     var passKeysSkipButton: XCUIElement {
-        rootElement.buttons["No thanks"]
+        rootElement.buttons["Not now"]
     }
 
     func enterCode(_ code: String) {


### PR DESCRIPTION
Device test [run](https://github.com/openpass-sso/openpass-api/actions/runs/16370733002/job/46372181382)s are failing after the 'skip' button label changed. Update the label to fix.