### PR TITLE
OPENPASS-3196 Rename CHECKOUT_TOKEN to CROSS_REPO_CHECKOUT_TOKEN

### DIFF
--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -37,6 +37,9 @@ on:
         required: true
       MAIL_SPY_API_KEY:
         required: true
+      CROSS_REPO_CHECKOUT_TOKEN:
+        required: false
+      # Deprecated: kept for backwards compat during caller migration. Drop after all callers use CROSS_REPO_CHECKOUT_TOKEN.
       CHECKOUT_TOKEN:
         required: false
 
@@ -54,7 +57,7 @@ jobs:
           repository: 'openpass-sso/openpass-ios-sdk'
           ref: ${{ inputs.ref }}
           path: ${{ inputs.working-directory }}
-          token: ${{ secrets.CHECKOUT_TOKEN || github.token }}
+          token: ${{ secrets.CROSS_REPO_CHECKOUT_TOKEN || secrets.CHECKOUT_TOKEN || github.token }}
           persist-credentials: false
 
       - name: Select Xcode 16.4


### PR DESCRIPTION
## Summary
- Rename the cross-repo checkout secret from `CHECKOUT_TOKEN` to `CROSS_REPO_CHECKOUT_TOKEN` for clarity at the call site.
- `CHECKOUT_TOKEN` kept as a deprecated fallback to avoid breaking openpass-api callers between merges. Drop in a follow-up once all callers migrate.

Coordinated with sibling SDK PRs (openpass-android-sdk, openpass-js-sdk) and openpass-api caller updates.

## Test plan
- [ ] Existing callers passing `CHECKOUT_TOKEN` continue to work (fallback chain).
- [ ] Callers updated to `CROSS_REPO_CHECKOUT_TOKEN` resolve to the same PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)